### PR TITLE
Add lzo-devel as a Pre-req

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,4 +1,3 @@
-
 mh virtual tape & library system.
 
 
@@ -40,6 +39,7 @@ Pre-req for a running mhvtl
 
 Pre-req to build/compile userspace:
 - zlib-devel
+- lzo-devel
 
 * To build an RPM
   ===============


### PR DESCRIPTION
lzo-devel is also required to build userspace

Else you get errors like:
vtltape.c:2859: error: ‘LZO_E_OK’ undeclared (first use in this function)
make[1]: **\* [vtltape.o] Error 1
