### PR TITLE
Fix install error

### DIFF
--- a/usr/Makefile
+++ b/usr/Makefile
@@ -25,6 +25,7 @@ PREFIX ?= /usr
 USR ?= vtl
 SUSER = root
 GROUP ?= vtl
+BINGROUP ?= bin
 MHVTL_HOME_PATH ?= /opt/mhvtl
 MHVTL_CONFIG_PATH ?= /etc/mhvtl
 CONFIG_PATH = $(shell echo $(MHVTL_CONFIG_PATH) | sed -e s'/\//\\\//g')


### PR DESCRIPTION
This PR fixs the following error when installing.

```
root@chttl3:~/src/mhvtl# make install
make usr
make[1]: Entering directory '/root/src/mhvtl'
make -C usr USR=vtl GROUP=vtl MHVTL_HOME_PATH=/opt/mhvtl MHVTL_CONFIG_PATH=/etc/mhvtl
make[2]: Entering directory '/root/src/mhvtl/usr'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/root/src/mhvtl/usr'
make[1]: Leaving directory '/root/src/mhvtl'
make -C usr install /usr/lib /usr
make[1]: Entering directory '/root/src/mhvtl/usr'
install -d -m 755 /usr/lib
install -o root -g  -m 755 libvtlscsi.so /usr/lib/
install: invalid group ‘-m’
Makefile:225: recipe for target 'install' failed
make[1]: *** [install] Error 1
make[1]: Leaving directory '/root/src/mhvtl/usr'
Makefile:75: recipe for target 'install' failed
make: *** [install] Error 2
```

Environment:
```
root@chttl3:~/src/mhvtl# uname -a
Linux chttl3 4.4.0-104-generic #127-Ubuntu SMP Mon Dec 11 12:16:42 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
root@chttl3:~/src/mhvtl# cat /etc/issue
Ubuntu 16.04.3 LTS \n \l
```