### PR TITLE
fix for 4.15 kernel timer API change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.ko
 *.o
+*~
+/cscope.*
 /etc/mhvtl
 /kernel/.*.ko.cmd
 /kernel/.*.o.cmd
@@ -19,3 +21,5 @@
 /usr/vtlcmd
 /usr/vtllibrary
 /usr/vtltape
+/man/*.1
+/man/*.5

--- a/kernel/mhvtl.c
+++ b/kernel/mhvtl.c
@@ -1077,12 +1077,12 @@ static const char *vtl_info(struct Scsi_Host *shp)
 	return vtl_parm_info;
 }
 
-static ssize_t vtl_opts_show(struct device_driver *ddp, char *buf)
+static ssize_t opts_show(struct device_driver *ddp, char *buf)
 {
 	return scnprintf(buf, PAGE_SIZE, "0x%x\n", vtl_opts);
 }
 
-static ssize_t vtl_opts_store(struct device_driver *ddp,
+static ssize_t opts_store(struct device_driver *ddp,
 				 const char *buf, size_t count)
 {
 	int opts;
@@ -1107,16 +1107,14 @@ opts_done:
 	vtl_cmnd_count = 0;
 	return count;
 }
-static DRIVER_ATTR(opts, S_IRUGO|S_IWUSR, vtl_opts_show, vtl_opts_store);
 
-static ssize_t vtl_major_show(struct device_driver *ddp, char *buf)
+static ssize_t major_show(struct device_driver *ddp, char *buf)
 {
 	return scnprintf(buf, PAGE_SIZE, "%d\n", vtl_major);
 }
-static DRIVER_ATTR(major, S_IRUGO, vtl_major_show, NULL);
 
-static ssize_t vtl_add_lu_action(struct device_driver *ddp,
-					const char *buf, size_t count)
+static ssize_t add_lu_store(struct device_driver *ddp,
+			    const char *buf, size_t count)
 {
 	int retval;
 	unsigned int minor;
@@ -1140,7 +1138,16 @@ static ssize_t vtl_add_lu_action(struct device_driver *ddp,
 
 	return count;
 }
-static DRIVER_ATTR(add_lu, S_IWUSR|S_IWGRP, NULL, vtl_add_lu_action);
+
+#ifdef DRIVER_ATTR
+static DRIVER_ATTR(opts, S_IRUGO|S_IWUSR, vtl_opts_show, vtl_opts_store);
+static DRIVER_ATTR(major, S_IRUGO, major_show, NULL);
+static DRIVER_ATTR(add_lu, S_IWUSR|S_IWGRP, NULL, add_lu_store);
+#else
+static DRIVER_ATTR_RW(opts);
+static DRIVER_ATTR_RO(major);
+static DRIVER_ATTR_WO(add_lu);
+#endif
 
 static int do_create_driverfs_files(void)
 {

--- a/kernel/mhvtl.c
+++ b/kernel/mhvtl.c
@@ -742,7 +742,8 @@ static void timer_intr_handler(struct timer_list *t)
 	unsigned long indx = sqcp->a_cmnd->serial_number;
 #else
 static void timer_intr_handler(unsigned long indx)
-  struct vtl_queued_cmd *sqcp = NULL;
+{
+	struct vtl_queued_cmd *sqcp = NULL;
 #endif
 	struct vtl_lu_info *lu;
 

--- a/kernel/mhvtl.c
+++ b/kernel/mhvtl.c
@@ -1140,7 +1140,7 @@ static ssize_t add_lu_store(struct device_driver *ddp,
 }
 
 #ifdef DRIVER_ATTR
-static DRIVER_ATTR(opts, S_IRUGO|S_IWUSR, vtl_opts_show, vtl_opts_store);
+static DRIVER_ATTR(opts, S_IRUGO|S_IWUSR, opts_show, opts_store);
 static DRIVER_ATTR(major, S_IRUGO, major_show, NULL);
 static DRIVER_ATTR(add_lu, S_IWUSR|S_IWGRP, NULL, add_lu_store);
 #else

--- a/usr/stklxx_pm.c
+++ b/usr/stklxx_pm.c
@@ -23,18 +23,20 @@ static struct smc_personality_template smc_pm = {
 
 static void update_stk_l_vpd_80(struct lu_phy_attr *lu)
 {
-	struct vpd *lu_vpd;
+	struct vpd **lu_vpd;
 	uint8_t *d;
 
-	lu_vpd = lu->lu_vpd[PCODE_OFFSET(0x80)];
+	lu_vpd = &lu->lu_vpd[PCODE_OFFSET(0x80)];
 
 	/* Unit Serial Number */
-	if (lu_vpd)	/* Free any earlier allocation */
-		dealloc_vpd(lu_vpd);
+	if (*lu_vpd) {	/* Free any earlier allocation */
+		dealloc_vpd(*lu_vpd);
+		*lu_vpd = NULL;
+	}
 
-	lu_vpd = alloc_vpd(0x12);
-	if (lu_vpd) {
-		d = lu_vpd->data;
+	*lu_vpd = alloc_vpd(0x12);
+	if (*lu_vpd) {
+		d = (*lu_vpd)->data;
 		/* d[4 - 15] Serial number of device */
 		snprintf((char *)&d[0], 13, "%-12s", lu->lu_serial_no);
 		/* Unique Logical Library Identifier */


### PR DESCRIPTION
This pull request includes changes from Martin Wilck as 4.15 requires 4.14 changes.
This fixes issue #16 and I tested the compilation against olders 3.xx kernels.