### PR TITLE
Fix simple compiler ussues

### DIFF
--- a/usr/tapeexerciser.c
+++ b/usr/tapeexerciser.c
@@ -326,7 +326,7 @@ int main(int argc, char *argv[])
 	struct mtpos mtpos;
 	char *dev = NULL;
 	int tape_fd;
-	int err, rc;
+	int err;
 	int count;
 
 	if (argc != 3) {
@@ -365,11 +365,11 @@ int main(int argc, char *argv[])
 	write_tape_pattern_1(tape_fd);
 	write_tape_pattern_2(tape_fd);
 
-	rc = read_test_1(tape_fd);
-	rc = read_test_2(tape_fd);
-	rc = read_test_3(tape_fd);
-	rc = read_test_4(tape_fd);
-	rc = read_test_5(tape_fd);
+	read_test_1(tape_fd);
+	read_test_2(tape_fd);
+	read_test_3(tape_fd);
+	read_test_4(tape_fd);
+	read_test_5(tape_fd);
 
 	err = ioctl(tape_fd, MTIOCGET, &mtstat); /* Query device status */
 	if (err) {

--- a/usr/vtllib.c
+++ b/usr/vtllib.c
@@ -44,6 +44,7 @@
 #include <sys/shm.h>
 #include <sys/msg.h>
 #include <time.h>
+#include <sys/sysmacros.h>
 #include <assert.h>
 #include "be_byteshift.h"
 #include "list.h"


### PR DESCRIPTION
This fixes issues found by gcc7 having to do with string copies that can truncate data.