### PR TITLE
Fix string print overruns.

### DIFF
--- a/usr/hp_smc_pm.c
+++ b/usr/hp_smc_pm.c
@@ -25,7 +25,7 @@ static void update_eml_vpd_80(struct lu_phy_attr *lu)
 	lu_vpd[pg] = alloc_vpd(0x12);
 	if (lu_vpd[pg]) {
 		d = lu_vpd[pg]->data;
-		snprintf((char *)&d[0], 10, "%-10s", lu->lu_serial_no);
+		snprintf((char *)&d[0], 11, "%-10.10s", lu->lu_serial_no);
 		/* Unique Logical Library Identifier */
 	} else {
 		MHVTL_ERR("Could not malloc(0x12) bytes, line %d", __LINE__);

--- a/usr/hp_ultrium_pm.c
+++ b/usr/hp_ultrium_pm.c
@@ -241,10 +241,10 @@ static void update_hp_vpd_cx(struct lu_phy_attr *lu, uint8_t pg, char *comp,
 	data = (char *)vpd_p->data;
 
 	data[3] = 0x5c;
-	snprintf(&data[4], 24, "%-24s", comp);
-	snprintf(&data[30], 18, "%-18s", vers);
-	snprintf(&data[49], 24, "%-24s", date);
-	snprintf(&data[73], 22, "%-22s", variant);
+	snprintf(&data[4], 25, "%-24.24s", comp);
+	snprintf(&data[30], 19, "%-18.18s", vers);
+	snprintf(&data[49], 25, "%-24.24s", date);
+	snprintf(&data[73], 23, "%-22.22s", variant);
 }
 
 static void init_ult_inquiry(struct lu_phy_attr *lu)

--- a/usr/ibm_smc_pm.c
+++ b/usr/ibm_smc_pm.c
@@ -174,9 +174,9 @@ static void update_ibm_3584_vpd_80(struct lu_phy_attr *lu)
 
 	d = lu_vpd[pg]->data;
 	/* d[4 - 15] Serial number of device */
-	snprintf((char *)&d[0], 10, "%-10s", lu->lu_serial_no);
+	snprintf((char *)&d[0], 11, "%-10.10s", lu->lu_serial_no);
 	/* First Storage Element Address */
-	snprintf((char *)&d[12], 4, "%04x", smc_p->pm->start_storage);
+	snprintf((char *)&d[12], 5, "%04x", smc_p->pm->start_storage);
 }
 
 static void update_ibm_3584_vpd_83(struct lu_phy_attr *lu)
@@ -210,7 +210,7 @@ static void update_ibm_3584_vpd_83(struct lu_phy_attr *lu)
 	/* Serial Number of device */
 	memcpy(&d[28], &lu->inquiry[38], 12);
 	/* First Storage Element Address */
-	snprintf((char *)&d[40], 4, "%04x", smc_p->pm->start_storage);
+	snprintf((char *)&d[40], 5, "%04x", smc_p->pm->start_storage);
 }
 
 static void update_ibm_3584_inquiry(struct lu_phy_attr *lu)
@@ -259,7 +259,7 @@ static void update_ibm_3100_vpd_80(struct lu_phy_attr *lu)
 
 	d = lu_vpd[pg]->data;
 	/* d[4 - 15] Serial number of device */
-	snprintf((char *)&d[0], 13, "%-12s", lu->lu_serial_no);
+	snprintf((char *)&d[0], 13, "%-12.12s", lu->lu_serial_no);
 	/* Unique Logical Library Identifier */
 	memset(&d[12], 0x20, 4);	/* Space chars */
 }

--- a/usr/overland_pm.c
+++ b/usr/overland_pm.c
@@ -26,7 +26,7 @@ static void update_eml_vpd_80(struct lu_phy_attr *lu)
 	if (lu_vpd[pg]) {
 		d = lu_vpd[pg]->data;
 		/* d[4 - 15] Serial number of device */
-		snprintf((char *)&d[0], 10, "%-10s", lu->lu_serial_no);
+		snprintf((char *)&d[0], 11, "%-10.10s", lu->lu_serial_no);
 		/* Unique Logical Library Identifier */
 	} else {
 		MHVTL_ERR("Could not malloc(0x12) bytes, line %d", __LINE__);

--- a/usr/quantum_dlt_pm.c
+++ b/usr/quantum_dlt_pm.c
@@ -157,8 +157,8 @@ static void update_vpd_dlt_c1(struct lu_phy_attr *lu, char *sn)
 	data[1] = 0xc1;
 	data[3] = 0x39;
 	data[4] = get_product_family(lu);
-	snprintf((char *)&data[4], 12, "%-12s", sn);
-	snprintf((char *)&data[24], 12, "%-12s", sn);
+	snprintf((char *)&data[4], 13, "%-12s", sn);
+	snprintf((char *)&data[24], 13, "%-12s", sn);
 }
 
 static uint8_t set_dlt_WORM(struct list_head *lst)

--- a/usr/scalar_pm.c
+++ b/usr/scalar_pm.c
@@ -52,7 +52,7 @@ static void update_scalar_vpd_80(struct  lu_phy_attr *lu)
 	if (lu_vpd) {
 		d = lu_vpd->data;
 		/* d[4 - 27] Serial number prefixed by Vendor ID */
-		snprintf((char *)&d[0], 25, "%-s%-17s", lu->vendor_id, lu->lu_serial_no);
+		snprintf((char *)&d[0], 26, "%-s%-17s", lu->vendor_id, lu->lu_serial_no);
 	} else {
 		MHVTL_ERR("Could not malloc(24) bytes, line %d", __LINE__);
 	}

--- a/usr/stklxx_pm.c
+++ b/usr/stklxx_pm.c
@@ -38,7 +38,7 @@ static void update_stk_l_vpd_80(struct lu_phy_attr *lu)
 	if (*lu_vpd) {
 		d = (*lu_vpd)->data;
 		/* d[4 - 15] Serial number of device */
-		snprintf((char *)&d[0], 13, "%-12s", lu->lu_serial_no);
+		snprintf((char *)&d[0], 13, "%-12.12s", lu->lu_serial_no);
 		/* Unique Logical Library Identifier */
 	} else {
 		MHVTL_ERR("Could not malloc(0x12) bytes, line %d", __LINE__);

--- a/usr/ult3580_pm.c
+++ b/usr/ult3580_pm.c
@@ -159,8 +159,8 @@ static void update_vpd_ult_c1(struct lu_phy_attr *lu, char *sn)
 
 	data[1] = 0xc1;
 	data[3] = 0x18;
-	snprintf((char *)&data[4], 12, "%-12s", sn);
-	snprintf((char *)&data[16], 12, "%-12s", sn);
+	snprintf((char *)&data[4], 13, "%-12.12s", sn);
+	snprintf((char *)&data[16], 13, "%-12.12s", sn);
 }
 
 static uint8_t set_ult_WORM(struct list_head *lst)

--- a/usr/vtllib.c
+++ b/usr/vtllib.c
@@ -382,7 +382,7 @@ uint32_t resp_read_media_serial(uint8_t *sno, uint8_t *buf, uint8_t *sam_stat)
 {
 	uint32_t size = 38;
 
-	snprintf((char *)&buf[4], size - 5, "%-34s", sno);
+	snprintf((char *)&buf[4], size - 3, "%-34.34s", sno);
 	put_unaligned_be16(size, &buf[2]);
 
 	return size;

--- a/usr/vtllib.h
+++ b/usr/vtllib.h
@@ -69,7 +69,7 @@ http://scaryreasoner.wordpress.com/2009/02/28/checking-sizeof-at-compile-time/
 #define SCSI_SN_LEN 16
 
 #define MAX_BARCODE_LEN	16
-#define LEFT_JUST_16_STR "%-16s"
+#define LEFT_JUST_16_STR "%-16.16s"
 
 #define MAX_INQ_ARR_SZ 64
 #define MALLOC_SZ 512

--- a/usr/vtllibrary.c
+++ b/usr/vtllibrary.c
@@ -487,7 +487,7 @@ static int load_map(struct q_msg *msg)
 		if (!mp)
 			mp = add_barcode(&lunit, barcode);
 
-		snprintf((char *)mp->barcode, MAX_BARCODE_LEN, LEFT_JUST_16_STR,
+		snprintf((char *)mp->barcode, MAX_BARCODE_LEN+1, LEFT_JUST_16_STR,
 						barcode);
 		mp->barcode[MAX_BARCODE_LEN] = '\0';
 

--- a/usr/vtltape.c
+++ b/usr/vtltape.c
@@ -432,7 +432,7 @@ int resp_report_density(struct priv_lu_ssc *lu_priv, uint8_t media,
 					mam.AssigningOrganization_1);
 		snprintf((char *)&ds[24], 9, "%-8s",
 					mam.media_info.density_name);
-		snprintf((char *)&ds[32], 20, "%-20s",
+		snprintf((char *)&ds[32], 21, "%-20.20s",
 					mam.media_info.description);
 		/* Fudge.. Now 'fix' up the spaces. */
 		for (a = 16; a < REPORT_DENSITY_LEN; a++)
@@ -456,7 +456,7 @@ int resp_report_density(struct priv_lu_ssc *lu_priv, uint8_t media,
 			put_unaligned_be32(di->capacity, &ds[12]);
 			snprintf((char *)&ds[16], 9, "%-8s", di->assigning_org);
 			snprintf((char *)&ds[24], 9, "%-8s", di->density_name);
-			snprintf((char *)&ds[32], 20, "%-20s",
+			snprintf((char *)&ds[32], 21, "%-20s",
 					di->description);
 			/* Fudge.. Now 'fix' up the spaces. */
 			for (a = 16; a < REPORT_DENSITY_LEN; a++)


### PR DESCRIPTION
The newer gcc7 compiler catches a class of error
where a truncated string printf can loose data. So
fix all of those.