### PR TITLE
Use ChangeLog date instead of build date

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -32,8 +32,8 @@ ifeq ($(shell grep lib64 /etc/ld.so.conf.d/* | wc -l),0)
 LIBDIR=lib
 endif
 
-MONTH = $(shell date +%B)
-YEAR = $(shell date +%Y)
+MONTH = $(shell date -r ../ChangeLog +%B)
+YEAR = $(shell date -r ../ChangeLog +%Y)
 
 PREFIX ?= /usr
 USR ?= vtl


### PR DESCRIPTION
Use ChangeLog date instead of build date in man-page headers
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

This date call works with GNU date and BSD date (e.g. MacOSX).