### PR TITLE
Cleanup string usage to make gcc7 happy.

### DIFF
--- a/usr/vtl_cart_type.c
+++ b/usr/vtl_cart_type.c
@@ -90,7 +90,7 @@ void update_home_dir(long lib_id)
 
 int get_cart_type(const char *barcode)
 {
-	char pcl_meta[1024];
+	char *pcl_meta = NULL;
 	char pcl[MAX_BARCODE_LEN + 1];
 	struct stat meta_stat;
 	uint64_t exp_size;
@@ -116,14 +116,15 @@ int get_cart_type(const char *barcode)
 		snprintf(currentPCL, ARRAY_SIZE(currentPCL), "%s/%s",
 						MHVTL_HOME_PATH, pcl);
 
-	snprintf(pcl_meta, ARRAY_SIZE(pcl_meta), "%s/meta", currentPCL);
+	asprintf(&pcl_meta, "%s/meta", currentPCL);
 
 	if (stat(pcl_meta, &meta_stat) == -1) {
 		MHVTL_DBG(2, "Couldn't find %s, trying previous default: %s/%s",
 				pcl_meta, MHVTL_HOME_PATH, pcl);
 		snprintf(currentPCL, ARRAY_SIZE(currentPCL), "%s/%s",
 						MHVTL_HOME_PATH, pcl);
-		snprintf(pcl_meta, ARRAY_SIZE(pcl_meta), "%s/meta", currentPCL);
+		free(pcl_meta);
+		asprintf(&pcl_meta, "%s/meta", currentPCL);
 	}
 
 	metafile = open(pcl_meta, O_RDONLY);
@@ -191,5 +192,7 @@ failed:
 	close(metafile);
 	MHVTL_DBG(3, "Opening media: %s (barcode %s), returning type %d",
 			currentPCL, barcode, rc);
+	if (pcl_meta)
+		free(pcl_meta);
 	return rc;
 }

--- a/usr/vtllibrary.c
+++ b/usr/vtllibrary.c
@@ -334,7 +334,7 @@ static void list_map(struct q_msg *msg)
 
 	list_for_each_entry(sp, slot_head, siblings) {
 		if (slotOccupied(sp) && sp->element_type == MAP_ELEMENT) {
-			strncat(c, (char *)sp->media->barcode, MAX_BARCODE_LEN);
+			strncat(c, (char *)sp->media->barcode, MAX_BARCODE_LEN+1);
 			MHVTL_DBG(2, "MAP slot %d full", sp->slot_location);
 		} else {
 			MHVTL_DBG(2, "MAP slot %d empty", sp->slot_location);
@@ -1843,22 +1843,22 @@ int main(int argc, char *argv[])
 
 				MHVTL_DBG(3, "\nDrive %d", sp->slot_location);
 
-				strncpy(s, dp->inq_vendor_id, 8);
+				strncpy(s, dp->inq_vendor_id, 8+2);
 				rmnl(s, ' ', 8);
 				s[8] = '\0';
 				MHVTL_DBG(3, "Vendor ID     : \"%s\"", s);
 
-				strncpy(s, dp->inq_product_id, 16);
+				strncpy(s, dp->inq_product_id, 16+2);
 				rmnl(s, ' ', 16);
 				s[16] = '\0';
 				MHVTL_DBG(3, "Product ID    : \"%s\"", s);
 
-				strncpy(s, dp->inq_product_rev, 4);
+				strncpy(s, dp->inq_product_rev, 4+2);
 				rmnl(s, ' ', 4);
 				s[4] = '\0';
 				MHVTL_DBG(3, "Revision Level: \"%s\"", s);
 
-				strncpy(s, dp->inq_product_sno, 10);
+				strncpy(s, dp->inq_product_sno, 10+2);
 				rmnl(s, ' ', 10);
 				s[10] = '\0';
 				MHVTL_DBG(3, "Product S/No  : \"%s\"", s);

--- a/usr/vtltape.c
+++ b/usr/vtltape.c
@@ -1765,8 +1765,9 @@ static int loadTape(char *PCL, uint8_t *sam_stat)
 	lu_ssc.tapeLoaded = TAPE_LOADING;
 	lu_ssc.pm->media_load(lu, TAPE_LOADED);
 
-	strncpy((char *)lu_ssc.mediaSerialNo, (char *)mam.MediumSerialNumber,
-				sizeof(mam.MediumSerialNumber) - 1);
+	snprintf((char *)lu_ssc.mediaSerialNo,
+		 sizeof(mam.MediumSerialNumber) - 1,
+		 (char *)mam.MediumSerialNumber);
 
 	MHVTL_DBG(1, "Media type '%s' loaded with S/No. : %s",
 			lookup_media_type(lu_ssc.pm->media_handling,


### PR DESCRIPTION
The gcc7 compiler, using the "-Werror=stringop-truncation" option,
is quite picky about possible string truncation, so cleanup ctring
usage to make it (and our program) happier.

There should be *no* functional changes.