### PR TITLE
Do noy remote mhvtl module when stopping service.

### DIFF
--- a/etc/mhvtl-load-modules.service.in
+++ b/etc/mhvtl-load-modules.service.in
@@ -13,7 +13,6 @@ Environment=VTL_DEBUG="0"
 EnvironmentFile=-@CONF_PATH@/mhvtl.conf
 ExecStart=/usr/sbin/modprobe mhvtl opts=${VTL_DEBUG}
 ExecStart=/usr/sbin/modprobe sg
-ExecStop=/usr/sbin/modprobe -ar mhvtl
 
 [Install]
 WantedBy=multi-user.target mhvtl.target


### PR DESCRIPTION
Removing the module on service stop means that each
new service start will increment the HBA number used,
which may effect some users. The memory overhead of
leaving the module loaded if the service is stopped
is minimal.

Reported-by: Mark Harvey <markh794@gmail.com>