### PR TITLE
correct vtltape and vtllibrary service dependencies

### DIFF
--- a/etc/vtllibrary@.service.in
+++ b/etc/vtllibrary@.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Documentation=man:vtllibrary(1) man:vtlcmd(1)
 Description=Robot Library Daemon for Virtual Tape & Robot Library
-Before=multi-user.target
+Before=mhvtl.target
 Requires=mhvtl-load-modules.service
 After=mhvtl-load-modules.service
 PartOf=mhvtl.target

--- a/etc/vtltape@.service.in
+++ b/etc/vtltape@.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Documentation=man:vtltape(1) man:vtlcmd(1)
 Description=Tape Daemon for Virtual Tape & Robot Library
-Before=multi-user.target
+Before=mhvtl.target
 Requires=mhvtl-load-modules.service
 After=mhvtl-load-modules.service
 PartOf=mhvtl.target


### PR DESCRIPTION
The templates for vtltape and vtllibrary should run
before mhvtl.target, not multi-user.target.

Reported-by: Frank Bui <fbui@suse.com>