### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/usr/mktape.c
+++ b/usr/mktape.c
@@ -66,6 +66,15 @@ static void usage(char *progname)
 	printf("\n");
 }
 
+int gettime()
+{
+	const char *source_date_epoch = getenv("SOURCE_DATE_EPOCH");
+	time_t t;
+	if ( source_date_epoch == NULL || (t = (time_t)strtoll(source_date_epoch, NULL, 10)) <= 0)
+		t = time(NULL);
+	return t;
+}
+
 int main(int argc, char *argv[])
 {
 	unsigned char sam_stat;
@@ -212,8 +221,8 @@ int main(int argc, char *argv[])
 	}
 	set_media_params(&mam, density);
 
-	sprintf((char *)mam.MediumSerialNumber, "%s_%d", pcl, (int)time(NULL));
-	sprintf((char *)mam.MediumManufactureDate, "%d", (int)time(NULL));
+	sprintf((char *)mam.MediumSerialNumber, "%s_%d", pcl, (int)gettime());
+	sprintf((char *)mam.MediumManufactureDate, "%d", (int)gettime());
 	sprintf((char *)mam.Barcode, "%-31s", pcl);
 
 	/* Create the PCL using the initialized MAM. */


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Without this patch, `/var/lib/mhvtl/CLN101L4/meta` and other meta files
differed for every build.

```diff
 00000100  54 4c 43 4c 4e 31 30 31  4c 34 5f 31 35 35 34 32  |TLCLN101L4_15542|
-00000110  30 39 32 32 36 00 00 00  00 00 00 00 00 00 00 00  |09226...........|
+00000110  30 39 33 30 32 00 00 00  00 00 00 00 00 00 00 00  |09302...........|
 00000120  00 00 00 00 03 80 00 00  00 7f 00 00 00 00 00 00  |................|
-00000130  00 00 31 35 35 34 32 30  39 32 32 36 00 00 46 46  |..1554209226..FF|
+00000130  00 00 31 35 35 34 32 30  39 33 30 32 00 00 46 46  |..1554209302..FF|
 00000140  06 08 00 00 00 00 00 00  00 00 14 00 76 74 6c 2d  |............vtl-|
```

Signed-off-by: Bernhard M. Wiedemann <bwiedemann@suse.de>

This PR was done while working on reproducible builds for openSUSE.