### PR TITLE
Add Vagrant file with install script for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 /scripts/update_device.conf
 /man/*.1
 /man/*.5
+
+# Vagrant specific files
+/vagrant/.vagrant
+/vagrant/*.log

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,29 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box_check_update = false
+
+  config.vm.define "ubuntu" do |instance|
+    instance.vm.box = "ubuntu/xenial64"
+  end
+
+  config.vm.define "centos" do |instance|
+    instance.vm.box = "centos7"
+  end
+
+  config.vm.define "opensuse" do |instance|
+    instance.vm.box = "toni03/opensuse-leap15"
+  end
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "2048"
+  end
+
+  config.vm.synced_folder "../", "/vagrant_data"
+
+  config.vm.provision "shell", inline: <<-SHELL
+    cd /vagrant_data/vagrant
+    sudo ./install.sh
+  SHELL
+end

--- a/vagrant/install.sh
+++ b/vagrant/install.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+echo "Script Begin"
+
+get_os_name(){
+    if [[ "$(hostnamectl | grep -i ubuntu | wc -l)" != "0" ]]; then
+        OS_NAME='ubuntu'
+    elif [[ "$(hostnamectl | grep -i sles | wc -l)" != "0" ]]; then
+        OS_NAME='sles'
+    elif [[ "$(hostnamectl | grep -i opensuse | wc -l)" != "0" ]]; then
+	OS_NAME='opensuse'
+    elif [[ "$(hostnamectl | grep -i centos | wc -l)" != "0" ]]; then
+        OS_NAME='centos'
+    else
+        echo 'This os is not supported!'
+        exit 1
+    fi
+    echo "OS_NAME is $OS_NAME"
+}
+
+# check our script has been started with root auth
+if [[ "$(id -u)" != "0" ]]; then
+	echo "This script must be run with root privileges. Please run again as either root or using sudo."
+	tput sgr0
+	exit 1
+fi
+
+get_os_name
+
+# Lets break the script if there are any errors
+set -e
+
+install_ubuntu_pre_req(){
+    sudo apt-get update && sudo apt-get install sysstat lzop liblzo2-dev liblzo2-2 mtx mt-st sg3-utils zlib1g-dev git lsscsi build-essential gawk alien fakeroot linux-headers-$(uname -r) -y
+}
+install_centos_pre_req(){
+    sudo yum update -y && sudo yum install -y git mc ntp gcc gcc-c++ make kernel-devel zlib-devel sg3_utils lsscsi mt-st mtx lzo lzo-devel perl-Config-General
+}
+install_sles_pre_req(){
+    echo "SLES/OpenSuse IS NOT YET SUPPORTED! Use it at your own risk!"
+
+    # Workaround so that we install the same kernel-devel and kernel-syms version as the running kernel.
+    UNAME_R=$(echo $(uname -r) | cut -d "-" -f-2)
+    PATCHED_KERNEL_VERSION=$(sudo zypper se -s kernel-devel | grep ${UNAME_R} | cut -d "|" -f4 | tr -d " ")
+    sudo zypper install -y --oldpackage kernel-devel-${PATCHED_KERNEL_VERSION}
+    sudo zypper install -y --oldpackage kernel-syms-${PATCHED_KERNEL_VERSION}
+
+    sudo zypper install -y git mc ntp gcc gcc-c++ make zlib-devel sg3_utils lsscsi mtx lzo lzo-devel perl-Config-General
+}
+
+install_pre_req(){
+    if [[ ${OS_NAME} == 'ubuntu' ]]; then
+        install_ubuntu_pre_req
+    elif [[ ${OS_NAME} == 'centos' ]]; then
+        install_centos_pre_req
+    elif [[ ${OS_NAME} == 'sles' ]] || [[ ${OS_NAME} == 'opensuse' ]]; then
+        install_sles_pre_req
+    fi
+}
+
+# Install required packages
+install_pre_req
+
+# Change to mhVTL folder
+cd ../
+make distclean
+cd kernel/
+make
+sudo make install
+cd ..
+make
+sudo make install
+
+# Load it
+sudo systemctl daemon-reload
+sudo systemctl enable mhvtl.target
+sudo systemctl start mhvtl.target
+
+sleep 3
+echo "Show your tape libraries now!"
+lsscsi


### PR DESCRIPTION
Currently this is working for Ubuntu and Centos, but not for opensuse. You can test it by:

`cd vagrant`

and then
`vagrant up ubuntu`
or
`vagrant up centos`
or
`vagrant up opensuse`

I think its good to have this kind or some kind of end-to-end (installation on dist) testing for this project.