### PR TITLE
Change Vagrantbox for Centos to one that is  publicly available

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "centos" do |instance|
-    instance.vm.box = "centos7"
+    instance.vm.box = "geerlingguy/centos7"
   end
 
   config.vm.define "opensuse" do |instance|


### PR DESCRIPTION
The `centos7` Vagrantbox is not available on https://app.vagrantup.com/boxes/search so I changed it to one that is publicly available.