### PR TITLE
Fix: Incorrect sg3_util package name in install instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -66,6 +66,10 @@ Note: we used to create a user and group called "vtl" to try to limit
 the possible system hazards of having root access. But we now feel
 that normal Linux permissions and security controls are sufficient.
 
+Also note: The package sg3-utils has a different name based on the distribution 
+used. Most distributions (Red Hat/Suse/Centos) use an underscore (sg3_utils).
+Debian based distributions (Debian/Ubuntu/Mint use a hyphen (sg3-utils). 
+
 Now build user space daemons:
 From the parent directory where you extracted the source.
 

--- a/INSTALL
+++ b/INSTALL
@@ -60,7 +60,7 @@ Pre-req to build/compile userspace:
 * To build from tar archive (Debian / Ubuntu):
   ============================================
  apt-get install lsscsi
- apt-get install sg3_utils
+ apt-get install sg3-utils
 
 Note: we used to create a user and group called "vtl" to try to limit
 the possible system hazards of having root access. But we now feel


### PR DESCRIPTION
I attempted to install on Linux Mint 20.

The package name of sg3_utils in the Install doc used an underscore not a hyphen.

This pull request updates the install doc.