### PR TITLE
Doc: Fix VTLlibrary man page error. Fix: man page typo T10Kb -> T10KB

### DIFF
--- a/man/edit_tape.1.in
+++ b/man/edit_tape.1.in
@@ -31,7 +31,7 @@ The media 'type' which can be: "data" , "WORM" (Write Once Read Many) or
 .TP
 \fB\-d density\fR
 Media density. Can be one of LTO1, LTO2, LTO3, LTO4, SDLT1, SDLT2, SDLT3, SDLT4, AIT1, AIT2, AIT3,
-AIT4, T10KA, T10Kb, T10KC, 9840A, 9840B, 9840C, 9840D, 9940A, 9940B, J1A, E05 and E06
+AIT4, T10KA, T10KB, T10KC, 9840A, 9840B, 9840C, 9840D, 9940A, 9940B, J1A, E05 and E06
 
 The 'J1A, E05 and E06' media densities refer to the IBM 03592 media types.
 

--- a/man/mktape.1.in
+++ b/man/mktape.1.in
@@ -99,7 +99,7 @@ Can be one of
 .BR AIT3 ,
 .BR AIT4 ,
 .BR T10KA ,
-.BR T10Kb ,
+.BR T10KB ,
 .BR T10KC ,
 .BR 9840A ,
 .BR 9840B ,

--- a/man/vtllibrary.1.in
+++ b/man/vtllibrary.1.in
@@ -42,7 +42,7 @@ daemon registers each
 .B vtltape(1)
 via message queue. The
 .B vtllibrary
-reads @HOME_PATH@/library_contents.*
+reads @CONFIG_PATH@/library_contents.*
 and dynamically builds an internal structure of Storage slots and Media Access slots.
 All media movement is performed on internal structures only. The configuration file
 is never changed, i.e. a re-start of the daemon will result in the loss of any


### PR DESCRIPTION
I found the man pages mktape and edittape refer to T10Kb tapes instead of T10KB tapes. I think this is an error as default_ssc_pm.c, t10000_pm.c and vtllib.c all use the latter.

Also the man page for vtllibrary incorrectly refers to the HOME_PATH as the location of the library_contents.* files. This has been changed to CONFIG_PATH.