### PR TITLE
Silence compiler complaints about string too long

### DIFF
--- a/usr/tape_util.c
+++ b/usr/tape_util.c
@@ -127,7 +127,7 @@ static void init_lunit(struct lu_phy_attr *lu, struct priv_lu_ssc *priv_lu)
 	lu->lu_private = priv_lu;
 	lu->sense_p = sense;
 	strncpy(lu->lu_serial_no, "ABC123", 7);
-	strncpy(lu->vendor_id, "TAPE_UTIL", 9);
+	strncpy(lu->vendor_id, "TAPE_UTL", 9);
 	strncpy(lu->product_id, "xyzz", 5);
 	INIT_LIST_HEAD(&lu->den_list);
 	INIT_LIST_HEAD(&lu->mode_pg);


### PR DESCRIPTION
The vendor ID field is 9 bytes long, and we are writing 9
bytes to it, so there is no room for the NULL, making
strncpy() and the compiler unhappy. Just copy one less
bytes.