### PR TITLE
Makefile infrastructure: fix passing variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 /scripts/update_device.conf
 /man/*.1
 /man/*.5
+/tcopy/tcopy
+local.mk
 
 # Vagrant specific files
 /vagrant/.vagrant

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ tar: distclean
 		 $(PARENTDIR)/tcopy/ \
 		 $(PARENTDIR)/include \
 		 $(PARENTDIR)/Makefile \
+		 $(PARENTDIR)/config.mk \
 		 $(PARENTDIR)/README \
 		 $(PARENTDIR)/INSTALL \
 		 $(PARENTDIR)/ChangeLog \

--- a/config.mk
+++ b/config.mk
@@ -1,0 +1,30 @@
+TOPDIR ?= $(CURDIR)
+
+VER ?= $(shell awk '/Version/ {print $$2}'  $(TOPDIR)/mhvtl-utils.spec)
+REL ?= $(shell awk -F'[ %]' '/Release/ {print $$2}' $(TOPDIR)/mhvtl-utils.spec)
+
+VERSION ?= $(VER).$(REL)
+EXTRAVERSION ?= $(if $(shell git show-ref 2>/dev/null),-git-$(shell git rev-parse --abbrev-ref HEAD))
+
+PREFIX ?= /usr
+MANDIR ?= /share/man
+
+MHVTL_HOME_PATH ?= /opt/mhvtl
+MHVTL_CONFIG_PATH ?= /etc/mhvtl
+SYSTEMD_GENERATOR_DIR ?= /lib/systemd/system-generators
+SYSTEMD_SERVICE_DIR ?= /lib/systemd/system
+
+ifeq ($(shell whoami),root)
+ROOTUID = YES
+endif
+
+ifeq ($(shell grep lib64$ /etc/ld.so.conf /etc/ld.so.conf.d/* | wc -l),0)
+LIBDIR ?= $(PREFIX)/lib
+else
+LIBDIR ?= $(PREFIX)/lib64
+endif
+
+-include $(TOPDIR)/local.mk
+
+HOME_PATH = $(subst /,\/,$(MHVTL_HOME_PATH))
+CONFIG_PATH = $(subst /,\/,$(MHVTL_CONFIG_PATH))

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -2,9 +2,7 @@
 # etc/Makefile
 #
 
-TOP_DIR ?= ..
-
-USR_DIR = $(TOP_DIR)/usr
+include ../config.mk
 
 TAPE_SERVICE_FILE = vtltape@.service
 LIB_SERVICE_FILE = vtllibrary@.service
@@ -16,14 +14,6 @@ LIB_CONTENTS_FILES = library_contents.10 library_contents.30
 
 GENERATE_DEVICE_CONF = generate_device_conf
 GENERATE_LIB_CONTENTS = generate_library_contents
-
-SYSTEMD_SERVICE_DIR ?= /lib/systemd/system
-
-MHVTL_CONFIG_PATH ?= /etc/mhvtl
-MHVTL_HOME_PATH ?= /opt/mhvtl
-
-CONFIG_PATH = $(shell echo $(MHVTL_CONFIG_PATH) | sed -e s'/\//\\\//g')
-HOME_PATH = $(shell echo $(MHVTL_HOME_PATH) | sed -e s'/\//\\\//g')
 
 # files that need to be generated
 GENERATOR_FILES=$(MHVTL_CONF_FILE).in \

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,12 +1,6 @@
 #
 # $Id: Makefile,v 1.2.2.3 2006-08-30 06:35:14 markh Exp $
 #
-# For Debian/Ubuntu systems
-# make ubuntu=1
-#
-# or for SuSE / RedHat systems
-# make
-#
 
 # CC=/usr/bin/gcc
 #
@@ -18,10 +12,12 @@ vtl-objs := mhvtl.o
 
 V	?= $(shell uname -r)
 
-ifeq ($(ubuntu),)
- KDIR	:= /lib/modules/$(V)/build
+ifneq ($(wildcard /lib/modules/$(V)/build),)
+KDIR := /lib/modules/$(V)/build
 else
- KDIR	:= /usr/src/linux-headers-$(V)/
+ifneq ($(wildcard /usr/src/linux-headers-$(V)),)
+KDIR := /usr/src/linux-headers-$(V)
+endif
 endif
 
 PWD	:= $(shell pwd)

--- a/man/Makefile
+++ b/man/Makefile
@@ -15,22 +15,10 @@
 # @ at the beginning of the first line tell make not to echo the commands as it run it.
 #
 
-VER = $(shell awk '/Version/ {print $$2}' ../mhvtl-utils.spec)
-REL = $(shell awk '/Release/ {print $$2}' ../mhvtl-utils.spec)
-
-VERSION ?= $(VER)
-EXTRAVERSION =  $(if $(shell git show-ref 2>/dev/null),-git-$(shell git show-ref --head --abbrev|head -1|awk '{print $$1}'))
+include ../config.mk
 
 MONTH = $(shell date -r ../ChangeLog +%B)
 YEAR = $(shell date -r ../ChangeLog +%Y)
-
-PREFIX ?= /usr
-MHVTL_HOME_PATH ?= /opt/mhvtl
-MHVTL_CONFIG_PATH ?= /etc/mhvtl
-MANDIR ?= /share/man
-
-CONFIG_PATH = $(shell echo $(MHVTL_CONFIG_PATH) | sed -e s'/\//\\\//g')
-HOME_PATH = $(shell echo $(MHVTL_HOME_PATH) | sed -e s'/\//\\\//g')
 
 objects = $(patsubst %.in,%,$(wildcard *.in))
 

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,9 +1,8 @@
 
-RCFILE = update_device.conf
-PREFIX ?= /usr
-MHVTL_CONFIG_PATH ?= /etc/mhvtl
+include ../config.mk
 
-CONFIG_PATH = $(shell echo $(MHVTL_CONFIG_PATH) | sed -e s'/\//\\\//g')
+RCFILE = update_device.conf
+
 $(RCFILE): $(RCFILE).in
 	sed -e s'/@CONF_PATH@/$(CONFIG_PATH)/' $< > $@
 

--- a/tcopy/Makefile
+++ b/tcopy/Makefile
@@ -1,10 +1,12 @@
 # Makefile for linux port of Tcopy
 # By Nicholas Harbour, 2000
 
+include ../config.mk
+
 BINARY=tcopy
 MANPAGE=tcopy.1
-BIN_PATH=/usr/bin/
-MAN_PATH=/usr/local/man/man1/
+BIN_PATH=$(PREFIX)/bin/
+MAN_PATH=$(PREFIX)/$(MANDIR)/man1/
 OBJS=tcopy.o
 CC=gcc
 OPTS=-Wall

--- a/usr/Makefile
+++ b/usr/Makefile
@@ -15,24 +15,7 @@
 # @ at the beginning of the first line tell make not to echo the commands as it run it.
 #
 
-VER = $(shell awk '/Version/ {print $$2}' ../mhvtl-utils.spec)
-REL = $(shell awk '/Release/ {print $$2}' ../mhvtl-utils.spec | sed 's/%{?dist}//g')
-
-VERSION ?= $(VER).$(REL)
-EXTRAVERSION =  $(if $(shell git show-ref 2>/dev/null),-git-$(shell git show-ref --head --abbrev|head -1|awk '{print $$1}'))
-
-PREFIX ?= /usr
-SYSTEMD_GENERATOR_DIR ?= /lib/systemd/system-generators
-MHVTL_HOME_PATH ?= /opt/mhvtl
-MHVTL_CONFIG_PATH ?= /etc/mhvtl
-CONFIG_PATH = $(shell echo $(MHVTL_CONFIG_PATH) | sed -e s'/\//\\\//g')
-HOME_PATH = $(shell echo $(MHVTL_HOME_PATH) | sed -e s'/\//\\\//g')
-
-ifeq ($(shell grep lib64$ /etc/ld.so.conf /etc/ld.so.conf.d/* | wc -l),0)
-LIBDIR ?= $(PREFIX)/lib
-else
-LIBDIR ?= $(PREFIX)/lib64
-endif
+include ../config.mk
 
 CFLAGS=-Wall -Wshadow -g -O2 -D_LARGEFILE64_SOURCE $(RPM_OPT_FLAGS) -I../kernel -I../ccan
 CFLAGS += -DMHVTL_VERSION=\"$(VERSION)$(EXTRAVERSION)\"
@@ -249,4 +232,3 @@ install: all
 
 tar:
 	make -C ../ tar
-


### PR DESCRIPTION
Centralise tweakable bits and bobs into `config.mk` which sub-Makefiles
include; `local.mk` (`.gitignore`'d) can be used to specify site-specific
overrides.