### PR TITLE
etc/Makefile: drop 'sh' from shell script invocation

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -43,10 +43,10 @@ $(GENERATE_LIB_CONTENTS): $(GENERATE_LIB_CONTENTS).in
 	chmod 755 $@
 
 $(DEVICE_CONF_FILE): $(GENERATE_DEVICE_CONF)
-	./$(GENERATE_DEVICE_CONF) --force --home-dir=$(MHVTL_HOME_PATH) --override-home
+	sh ./$(GENERATE_DEVICE_CONF) --force --home-dir=$(MHVTL_HOME_PATH) --override-home
 
 $(LIB_CONTENTS_FILES): $(GENERATE_LIB_CONTENTS) $(DEVICE_CONF_FILE)
-	./$(GENERATE_LIB_CONTENTS) --force --config=.
+	sh ./$(GENERATE_LIB_CONTENTS) --force --config=.
 
 .PHONY: distclean
 distclean: clean

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -43,10 +43,10 @@ $(GENERATE_LIB_CONTENTS): $(GENERATE_LIB_CONTENTS).in
 	chmod 755 $@
 
 $(DEVICE_CONF_FILE): $(GENERATE_DEVICE_CONF)
-	sh ./$(GENERATE_DEVICE_CONF) --force --home-dir=$(MHVTL_HOME_PATH) --override-home
+	./$(GENERATE_DEVICE_CONF) --force --home-dir=$(MHVTL_HOME_PATH) --override-home
 
 $(LIB_CONTENTS_FILES): $(GENERATE_LIB_CONTENTS) $(DEVICE_CONF_FILE)
-	sh ./$(GENERATE_LIB_CONTENTS) --force --config=.
+	./$(GENERATE_LIB_CONTENTS) --force --config=.
 
 .PHONY: distclean
 distclean: clean

--- a/usr/mhvtl-device-conf-generator.c
+++ b/usr/mhvtl-device-conf-generator.c
@@ -221,7 +221,7 @@ int main(int argc, char **argv)
 		exit(1);
 
 	/*
-	 * parse the config file /etc/mhvtl/device.conf
+	 * parse the device.conf config file
 	 *
 	 * for each library found:
 	 *	- set up vtllibrary unit


### PR DESCRIPTION
The `etc/generate_*` scripts are `bash` scripts, not `sh` ones.
There's no point in invoking them through a specific shell anyway,
as they are executable on their own rights.

Fixes building on systems where `sh` is not `bash` (Debian-derived
defaults).