### PR TITLE
etc/Makefile: invoke bash scripts using 'bash', not 'sh'

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -43,10 +43,10 @@ $(GENERATE_LIB_CONTENTS): $(GENERATE_LIB_CONTENTS).in
 	chmod 755 $@
 
 $(DEVICE_CONF_FILE): $(GENERATE_DEVICE_CONF)
-	sh ./$(GENERATE_DEVICE_CONF) --force --home-dir=$(MHVTL_HOME_PATH) --override-home
+	bash ./$(GENERATE_DEVICE_CONF) --force --home-dir=$(MHVTL_HOME_PATH) --override-home
 
 $(LIB_CONTENTS_FILES): $(GENERATE_LIB_CONTENTS) $(DEVICE_CONF_FILE)
-	sh ./$(GENERATE_LIB_CONTENTS) --force --config=.
+	bash ./$(GENERATE_LIB_CONTENTS) --force --config=.
 
 .PHONY: distclean
 distclean: clean

--- a/usr/mhvtl-device-conf-generator.c
+++ b/usr/mhvtl-device-conf-generator.c
@@ -221,7 +221,7 @@ int main(int argc, char **argv)
 		exit(1);
 
 	/*
-	 * parse the config file /etc/mhvtl/device.conf
+	 * parse the device.conf config file
 	 *
 	 * for each library found:
 	 *	- set up vtllibrary unit


### PR DESCRIPTION
I was a bit quick to cancel the other one - here's one anew. Instead of dropping the explicit shell
invocation, use the correct shell then to invoke the scripts with.