### PR TITLE
vtlcart: Replace calls to creat() with calls to open()

### DIFF
--- a/usr/vtlcart.c
+++ b/usr/vtlcart.c
@@ -695,7 +695,7 @@ int create_tape(const char *pcl, const struct MAM *mamp, uint8_t *sam_stat)
 
 	if (verbose)
 		printf("Creating new media data file: %s\n", newMedia_data);
-	datafile = creat(newMedia_data, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
+	datafile = open(newMedia_data, O_CREAT|O_TRUNC|O_WRONLY, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
 	if (datafile == -1) {
 		MHVTL_ERR("Failed to create file %s: %s", newMedia_data,
 			strerror(errno));
@@ -704,7 +704,7 @@ int create_tape(const char *pcl, const struct MAM *mamp, uint8_t *sam_stat)
 	}
 	if (verbose)
 		printf("Creating new media index file: %s\n", newMedia_indx);
-	indxfile = creat(newMedia_indx, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
+	indxfile = open(newMedia_indx, O_CREAT|O_TRUNC|O_WRONLY, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
 	if (indxfile == -1) {
 		MHVTL_ERR("Failed to create file %s: %s", newMedia_indx,
 			strerror(errno));
@@ -714,7 +714,7 @@ int create_tape(const char *pcl, const struct MAM *mamp, uint8_t *sam_stat)
 	}
 	if (verbose)
 		printf("Creating new media meta file: %s\n", newMedia_meta);
-	metafile = creat(newMedia_meta, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
+	metafile = open(newMedia_meta, O_CREAT|O_TRUNC|O_WRONLY, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
 	if (metafile == -1) {
 		MHVTL_ERR("Failed to create file %s: %s", newMedia_meta,
 			strerror(errno));

--- a/usr/vtlcart_v1.c
+++ b/usr/vtlcart_v1.c
@@ -589,7 +589,7 @@ create_tape(const char *pcl, const struct MAM *mamp, uint8_t *sam_stat)
 
 	sprintf((char *)newMedia, "%s/%s", MHVTL_HOME_PATH, pcl);
 	syslog(LOG_DAEMON|LOG_INFO, "%s being created", newMedia);
-	datafile = creat((char *)newMedia,S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
+	datafile = open((char *)newMedia, O_CREAT|O_TRUNC|O_WRONLY, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
 	if (datafile == -1) {
 		perror("Failed creating file");
 		return 2;

--- a/usr/vtlcart_v1_mtr.c
+++ b/usr/vtlcart_v1_mtr.c
@@ -627,7 +627,7 @@ int create_tape(const char *pcl, const struct MAM *mamp, uint8_t *sam_stat)
 	 */
 	sprintf((char *)newMedia, "%s/%s", MHVTL_HOME_PATH, pcl);
 	syslog(LOG_DAEMON|LOG_INFO, "%s being created", newMedia);
-	datafile = creat((char *)newMedia, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
+	datafile = open((char *)newMedia, O_CREAT|O_TRUNC|O_WRONLY, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
 	if (datafile == -1) {
 		perror("Failed creating file");
 		return 2;


### PR DESCRIPTION
The creat() interface is considered to have been obsoleted by open():

https://pubs.opengroup.org/onlinepubs/9699919799/functions/creat.html