### PR TITLE
Fix removal of genhd

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -29,36 +29,34 @@ PWD	:= $(shell pwd)
 default:	config.h
 	$(MAKE) -C $(KDIR) M=$(PWD) modules
 
-config.h:
+config.h: config.sh
 	./config.sh
 
 clean:
-	rm -f mhvtl.ko
+	$(RM) mhvtl.ko
+	$(RM) *.o
 	$(RM) TAGS
 
-distclean:
-	rm -f mhvtl.o mhvtl.ko \
-	*.o \
-	.*.o.d \
-	mhvtl.mod.c \
-	Modules.symvers \
-	Module.symvers \
-	.mhvtl.ko.cmd \
-	.mhvtl.o.cmd \
-	.mhvtl.mod.o.cmd \
-	.event.o.cmd \
-	.event.o.d \
-	.Module.symvers.cmd \
-	.mhvtl.mod.cmd \
-	.modules.order.cmd \
-	mhvtl.mod \
-	Module.markers \
-	modules.order \
-	mhvtl.ko.unsigned \
-	.mhvtl.ko.unsigned.cmd \
-	TAGS \
-	config.h
-	rm -rf .tmp_versions
+distclean: clean
+	$(RM) .*.o.d \
+	    mhvtl.mod.c \
+	    Modules.symvers \
+	    Module.symvers \
+	    .mhvtl.ko.cmd \
+	    .mhvtl.o.cmd \
+	    .mhvtl.mod.o.cmd \
+	    .event.o.cmd \
+	    .event.o.d \
+	    .Module.symvers.cmd \
+	    .mhvtl.mod.cmd \
+	    .modules.order.cmd \
+	    mhvtl.mod \
+	    Module.markers \
+	    modules.order \
+	    mhvtl.ko.unsigned \
+	    .mhvtl.ko.unsigned.cmd \
+	    config.h
+	$(RM) -r .tmp_versions
 
 install:
 	install -o root -g root -m 644 mhvtl.ko /lib/modules/$(V)/kernel/drivers/scsi/; \

--- a/kernel/backport.h
+++ b/kernel/backport.h
@@ -48,11 +48,6 @@ static inline struct inode *file_inode(struct file *f)
 }
 #endif
 
-/* HAVE_UNLOCKED_IOCTL removed in linux/fs.h for kernels 5.9+ */
-#if LINUX_VERSION_CODE > KERNEL_VERSION(5, 8, 0)
-#define HAVE_UNLOCKED_IOCTL 1
-#endif
-
 #if !defined(HAVE_SYSFS_EMIT)
 /* https://patches.linaro.org/project/stable/patch/20210305120853.392925382@linuxfoundation.org/ */
 /**

--- a/kernel/mhvtl.c
+++ b/kernel/mhvtl.c
@@ -50,7 +50,6 @@
 #include <linux/timer.h>
 #include <linux/types.h>
 #include <linux/string.h>
-#include <linux/genhd.h>
 #include <linux/fs.h>
 #include <linux/init.h>
 #include <linux/moduleparam.h>
@@ -93,6 +92,10 @@ struct scatterlist;
 
 #include "vtl_common.h"
 #include "backport.h"
+
+#if defined(HAVE_GENHD)
+#include <linux/genhd.h>
+#endif
 
 #include <scsi/scsi_driver.h>
 #include <scsi/scsi_ioctl.h>


### PR DESCRIPTION
This fixes a build issue for the kernel module, so that it handles the recent remove of <genhd.h>. While I was there, I cleaned up config.sh, and I fixed an issue with HAVE_UNLOCKED_IOCTL by moving it into config.sh. The kernel Makefile's "clean" and "distclean" targets were cleaned up, as well.

Tested on kernels 5.18 (openSUSE Tumbleweed) and 5.3 (openSUSE Leap 15.3).