### PR TITLE
Fix possible double define of HAVE_UNLOCKED_IOCTL

### DIFF
--- a/kernel/config.sh
+++ b/kernel/config.sh
@@ -68,7 +68,9 @@ fi >> "${output}"
 # (otherwise, just "ioctl")
 syms[file_operations]='fs.h'
 if grep -q unlocked_ioctl "${hdrs}/include/linux/fs.h"; then
+    echo "#ifndef HAVE_UNLOCKED_IOCTL"
     echo "#define HAVE_UNLOCKED_IOCTL"
+    echo "#endif"
 else
     echo "#undef HAVE_UNLOCKED_IOCTL"
 fi >> "${output}"


### PR DESCRIPTION
Commit:

> 6e8175315554 (fix-double-define-of-have_unlocked_ioctl) kernel:
>   Handle removal of genhd.h from linux includes.

moved definition of HAVE_UNLOCKED_IOCTL to config.sh/config.h,
but this new logic doesn't account for the fact that older
kernels define their own macro of the same name.

So put guards around the definition of HAVE_UNLOCKED_IOCTL, only
defining it if needed.