### PR TITLE
Change minimum block size to 1 byte to prevent data loss when writing file on size boundary

### DIFF
--- a/usr/vtllib.c
+++ b/usr/vtllib.c
@@ -388,10 +388,10 @@ int resp_read_block_limits(struct mhvtl_ds *dbuf_p, int sz)
 {
 	uint8_t *arr = (uint8_t *)dbuf_p->data;
 
-	MHVTL_DBG(2, "Min/Max sz: %d/%d", 4, sz);
+	MHVTL_DBG(2, "Min/Max sz: %d/%d", 1, sz);
 	memset(arr, 0, READBLOCKLIMITS_ARR_SZ);
 	put_unaligned_be24(sz, &arr[1]);
-	arr[5] = 0x4;	/* Minimum block size */
+	arr[5] = 0x1;	/* Minimum block size */
 
 	return READBLOCKLIMITS_ARR_SZ;
 }


### PR DESCRIPTION
If a file is written to a virtual tape device with a size that is 1,2 or 3 bytes larger than the a multiple of 2MB (including zero), the write will drop the additional bytes.

I have create a test script here:
https://gist.github.com/nrichtapeark/269ebc51563af6800acad18aef513ca6
