### PR TITLE
Handle queuecommand arg change

### DIFF
--- a/kernel/config.sh
+++ b/kernel/config.sh
@@ -86,4 +86,3 @@ else
 fi >> "${output}"
 
 printf '\n\n#endif /* _MHVTL_KERNEL_CONFIG_H */\n' >> "${output}"
-

--- a/kernel/config.sh
+++ b/kernel/config.sh
@@ -75,4 +75,15 @@ else
     echo "#undef HAVE_UNLOCKED_IOCTL"
 fi >> "${output}"
 
+# check for the scsi queue command taking one or two args
+str=$( grep 'rc = func_name##_lck' ${hdrs}/include/scsi/scsi_host.h )
+if [[ "$str" == *,* ]] ; then
+    echo "#undef QUEUECOMMAND_LCK_ONE_ARG"
+else
+    echo "#ifndef QUEUECOMMAND_LCK_ONE_ARG"
+    echo "#define QUEUECOMMAND_LCK_ONE_ARG"
+    echo "#endif"
+fi >> "${output}"
+
 printf '\n\n#endif /* _MHVTL_KERNEL_CONFIG_H */\n' >> "${output}"
+


### PR DESCRIPTION
This makes choosing how to call mhvtl_queuecommand_lck() semantic rather than version-based, as we now look and see if we need one argument or two, instead of assuming the result based on kernel version. This handles the cases where distributions back-port this change to earlier kernels.