### PR TITLE
Add used, but undeclared variable fg into vtltape::processMessageQ() function

### DIFF
--- a/usr/vtltape.c
+++ b/usr/vtltape.c
@@ -1494,6 +1494,7 @@ static int processMessageQ(struct q_msg *msg, uint8_t *sam_stat)
 	int rc;
 	struct lu_phy_attr *lu;
 	int pcl_len;
+	uint64_t fg = TA_NONE;	/* TapeAlert flags */
 
 	lu = lu_ssc.pm->lu;
 


### PR DESCRIPTION
Reproducing same steps I undertook locally to get mhvtl compiling. But without really taking the time to fully understand the history behind the cause of this compilation error (whether this was a new variable introduced or whether the declaration had been removed).