### PR TITLE
Fix issue with DEFINE_SEMAPHORE in kernel module

### DIFF
--- a/kernel/config.sh
+++ b/kernel/config.sh
@@ -86,4 +86,13 @@ else
     echo "#endif"
 fi >> "${output}"
 
+# check for DEFINE_SEMAPHORE() taking an argument or not
+if grep -q 'DEFINE_SEMAPHORE(_name, _n)' "${hdrs}/include/linux/semaphore.h"; then
+    echo "#ifndef DEFINE_SEMAPHORE_HAS_NUMERIC_ARG"
+    echo "#define DEFINE_SEMAPHORE_HAS_NUMERIC_ARG"
+    echo "#endif"
+else
+    echo "#undef DEFINE_SEMAPHORE_HAS_NUMERIC_ARG"
+fi >> "${output}"
+
 printf '\n\n#endif /* _MHVTL_KERNEL_CONFIG_H */\n' >> "${output}"

--- a/kernel/mhvtl.c
+++ b/kernel/mhvtl.c
@@ -1631,7 +1631,11 @@ give_up:
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37)
+#if defined(DEFINE_SEMAPHORE_HAS_NUMERIC_ARG)
+static DEFINE_SEMAPHORE(tmp_mutex, 1);
+#else
 static DEFINE_SEMAPHORE(tmp_mutex);
+#endif /* DEFINE_SEMAPHORE_HAS_NUMERIC_ARG */
 #else
 static DECLARE_MUTEX(tmp_mutex);
 #endif


### PR DESCRIPTION
Upstream kernel 6.4 modified the DEFINE_SEMAPHORE() macro so that it takes a numeric argument. Handle that case, when needed, by checking in config.sh and handling both options in mhvtl.c