### PR TITLE
Normalize tar file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ install: all
 	$(MAKE) -C man man
 	$(MAKE) -C man install
 	[ -d $(DESTDIR)$(MHVTL_HOME_PATH) ] || mkdir -p $(DESTDIR)$(MHVTL_HOME_PATH)
-	(cd kernel; tar cfz ../mhvtl_kernel.tgz *)
+	(cd kernel; tar --sort=name --mtime=@1 --format=gnu -czf ../mhvtl_kernel.tgz *)
 	[ -d $(DESTDIR)$(FIRMWAREDIR)/mhvtl ] || mkdir -p $(DESTDIR)$(FIRMWAREDIR)/mhvtl
 	install -m 755 mhvtl_kernel.tgz $(DESTDIR)$(FIRMWAREDIR)/mhvtl/
 ifeq ($(ROOTUID),YES)


### PR DESCRIPTION
This patch is as simple as possible.
For this it assumed that the consumer understands GNU tar format
and does not care about mtimes.

This patch was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).