### PR TITLE
Fix bug in make_vtl_media that prevents detection of WORM media

### DIFF
--- a/usr/make_vtl_media.in
+++ b/usr/make_vtl_media.in
@@ -62,7 +62,7 @@ set_media_type()
 	MEDIA_TYPE="data"
 
 	if [[ $type =~ ^"W" ]]; then
-		MEDIA_TYPE="work"
+		MEDIA_TYPE="WORM"
 	elif [[ $type =~ ^"CLN" ]]; then
 		MEDIA_TYPE="clean"
 	# Match JW / JX as 'worm' media


### PR DESCRIPTION
Barcodes with a leading "W" indicate WORM media. make_vtl_media detects the media type by parsing the barcode and calls mktape with the appropriate arguments. This bug resulted in mktape being called with "-t work" instead of "-t WORM".