### PR TITLE
Fix naming and .sdev_configure signature for kernel v6.14

### DIFF
--- a/kernel/config.sh
+++ b/kernel/config.sh
@@ -114,4 +114,15 @@ else
     echo "#undef DEFINE_CONST_STRUCT_DEVICE_DRIVER"
 fi >> "${output}"
 
+# check if slave_configure has been renamed to sdev_configure
+if fgrep -q 'int (* sdev_configure)(struct scsi_device *, struct queue_limits *lim);' \
+    "${hdrs}/include/scsi/scsi_host.h"; then
+    echo "#ifndef DEFINE_QUEUE_LIMITS_SCSI_DEV_CONFIGURE"
+    echo "#define DEFINE_QUEUE_LIMITS_SCSI_DEV_CONFIGURE"
+    echo "#endif"
+else
+    echo "#undef DEFINE_QUEUE_LIMITS_SCSI_DEV_CONFIGURE"
+fi >> "${output}"
+
+
 printf '\n\n#endif /* _MHVTL_KERNEL_CONFIG_H */\n' >> "${output}"


### PR DESCRIPTION
I was trying to compile the kernel module against v6.14 and found couple of error regarding renaming and a change to  slave_configure. 

Upstream changes:

[[PATCH v4 0/5] scsi: Rename .slave_alloc() and .slave_destroy()](https://lore.kernel.org/all/20241022180839.2712439-1-bvanassche@acm.org/)
[[PATCH 10/23] scsi: add a device_configure method to the host template](https://lore.kernel.org/linux-usb/20240409143748.980206-11-hch@lst.de)
