### PR TITLE
mhvtl: kernel: fix build issue if RealTime kernel

### DIFF
--- a/kernel/mhvtl.c
+++ b/kernel/mhvtl.c
@@ -1104,7 +1104,7 @@ static int mhvtl_add_device(unsigned int minor, struct mhvtl_ctl *ctl)
 	lu->mhvtl_hba = mhvtl_hba;
 	lu->reset = 0;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39)
-	lu->cmd_list_lock = __SPIN_LOCK_UNLOCKED(lu.cmd_list_lock);
+	spin_lock_init(&lu->cmd_list_lock);
 #else
 	lu->cmd_list_lock = SPIN_LOCK_UNLOCKED;
 #endif


### PR DESCRIPTION
If CONFIG_PREEMPT_RT is defined, as it is for the new SUSE kernel, where Real Time has been enabled, usage of the __SPIN_LOCK_UNLOCKED() macro fails to compile:

```
[   39s] + make -C /usr/src/linux-obj/x86_64/rt 'EXTRA_CFLAGS=-Iinclude -DMHVTL_DEBUG -DHAVE_UNLOCKED_IOCTL' modules M=/home/abuild/rpmbuild/BUILD/mhvtl-1.72_release+0.70719883aae2-build/mhvtl-1.72_release+0.70719883aae2/obj/rt
[   39s] make: Entering directory '/usr/src/linux-6.12.0-160000.11-obj/x86_64/rt'
[   40s]   CC [M]  /home/abuild/rpmbuild/BUILD/mhvtl-1.72_release+0.70719883aae2-build/mhvtl-1.72_release+0.70719883aae2/obj/rt/mhvtl.o
[   40s] In file included from /usr/src/linux-6.12.0-160000.11/include/linux/mutex_types.h:8,
[   40s]                  from /usr/src/linux-6.12.0-160000.11/include/linux/sched.h:25,
[   40s]                  from /usr/src/linux-6.12.0-160000.11/include/linux/percpu.h:12,
[   40s]                  from /usr/src/linux-6.12.0-160000.11/arch/x86/include/asm/msr.h:15,
[   40s]                  from /usr/src/linux-6.12.0-160000.11/arch/x86/include/asm/tsc.h:10,
[   40s]                  from /usr/src/linux-6.12.0-160000.11/arch/x86/include/asm/timex.h:6,
[   40s]                  from /usr/src/linux-6.12.0-160000.11/include/linux/timex.h:67,
[   40s]                  from /usr/src/linux-6.12.0-160000.11/include/linux/time32.h:13,
[   40s]                  from /usr/src/linux-6.12.0-160000.11/include/linux/time.h:60,
[   40s]                  from /usr/src/linux-6.12.0-160000.11/include/linux/stat.h:19,
[   40s]                  from /usr/src/linux-6.12.0-160000.11/include/linux/module.h:13,
[   40s]                  from /home/abuild/rpmbuild/BUILD/mhvtl-1.72_release+0.70719883aae2-build/mhvtl-1.72_release+0.70719883aae2/obj/rt/mhvtl.c:45:
[   40s] /home/abuild/rpmbuild/BUILD/mhvtl-1.72_release+0.70719883aae2-build/mhvtl-1.72_release+0.70719883aae2/obj/rt/mhvtl.c: In function â€˜mhvtl_add_deviceâ€™:
[   40s] /usr/src/linux-6.12.0-160000.11/include/linux/spinlock_types.h:58:9: error: expected expression before â€˜{â€™ token
[   40s]    58 |         {                                                       \
[   40s]       |         ^
[   40s] /home/abuild/rpmbuild/BUILD/mhvtl-1.72_release+0.70719883aae2-build/mhvtl-1.72_release+0.70719883aae2/obj/rt/mhvtl.c:1107:29: note: in expansion of macro â€˜__SPIN_LOCK_UNLOCKEDâ€™
[   40s]  1107 |         lu->cmd_list_lock = __SPIN_LOCK_UNLOCKED(lu.cmd_list_lock);
[   40s]       |                             ^~~~~~~~~~~~~~~~~~~~
[   40s] make[2]: *** [/usr/src/linux-6.12.0-160000.11/scripts/Makefile.build:229: /home/abuild/rpmbuild/BUILD/mhvtl-1.72_release+0.70719883aae2-build/mhvtl-1.72_release+0.70719883aae2/obj/rt/mhvtl.o] Error 1
[   40s] make[1]: *** [/usr/src/linux-6.12.0-160000.11/Makefile:1968: /home/abuild/rpmbuild/BUILD/mhvtl-1.72_release+0.70719883aae2-build/mhvtl-1.72_release+0.70719883aae2/obj/rt] Error 2
[   40s] make: *** [../../../linux-6.12.0-160000.11/Makefile:224: __sub-make] Error 2
[   40s] make: Leaving directory '/usr/src/linux-6.12.0-160000.11-obj/x86_64/rt'
```

It looks like this macro was always used incorrectly, but it only gets caught if Real Time is enabled in the kernel.

The __SPIN_LOCK_UNLOCKED() macro is meant to be used for variable static initialization, not for dynamic use, as can be seen elsewhere in the kernel. It was also passing in a value of "lu.cmd_list_lock", but it should have been "lu->cmd_list_lock".

Fix this by using spin_lock_init(), which is meant for dynamic use.