### PR TITLE
kernel module: handle rename of from_timer() to timer_container_of() in v6.16

### DIFF
--- a/kernel/config.sh
+++ b/kernel/config.sh
@@ -178,4 +178,15 @@ else
     echo "#undef USE_TIMER_DELETE_NOT_DEL_TIMER"
 fi >> "${output}"
 
+#
+# has "from_timer()" been renamed to "timer_container_of()"?
+#
+if grep -F -q 'timer_container_of(' "${hdrs}/linux/timer.h"; then
+    echo "#ifndef FROM_TIMER_NOW_TIMER_CONTAINER_OF"
+    echo "#define FROM_TIMER_NOW_TIMER_CONTAINER_OF"
+    echo "#endif"
+else
+    echo "#undef FROM_TIMER_NOW_TIMER_CONTAINER_OF"
+fi >> "${output}"
+
 printf '\n\n#endif /* _MHVTL_KERNEL_CONFIG_H */\n' >> "${output}"

--- a/kernel/mhvtl.c
+++ b/kernel/mhvtl.c
@@ -791,7 +791,12 @@ static void mhvtl_remove_sqcp(struct mhvtl_lu_info *lu, struct mhvtl_queued_cmd 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
 static void mhvtl_timer_intr_handler(struct timer_list *t)
 {
+#ifdef FROM_TIMER_NOW_TIMER_CONTAINER_OF
+	struct mhvtl_queued_cmd *sqcp = timer_container_of(sqcp, t,
+							   cmnd_timer);
+#else
 	struct mhvtl_queued_cmd *sqcp = from_timer(sqcp, t, cmnd_timer);
+#endif
 	unsigned long long indx = sqcp->serial_number;
 #else
 static void mhvtl_timer_intr_handler(unsigned long indx)


### PR DESCRIPTION
This is a 6.16 kernel change, from "from_timer()" to "timer_container_of()" in timer.h.

The difference should be detected automatically.