### PR TITLE
Fix returned length of READ ATTRIBUTE response

### DIFF
--- a/usr/vtltape.c
+++ b/usr/vtltape.c
@@ -701,10 +701,8 @@ int resp_read_attribute(struct scsi_cmd *cmd)
 
 	put_unaligned_be32(ret_val, &buf[0]);
 
-	if ((uint32_t)ret_val > alloc_len)
-		ret_val = alloc_len;
-
-	return ret_val;
+	/* Add 4 bytes for the AVAILABLE DATA length field. */
+	return min(ret_val + 4, alloc_len);
 }
 
 /*


### PR DESCRIPTION
The response of the READ ATTRIBUTE command is prefixed with a 4-byte length.
By returning `ret_val`, the response is truncated by 4-byte.


<img width="858" height="368" alt="Screenshot 2025-08-22 at 09 27 34" src="https://github.com/user-attachments/assets/42b15f32-b784-4b8b-8d70-629e6af43a47" />

