### PR TITLE
Fix Other Tape sizes like ff898da

### DIFF
--- a/usr/hp_ultrium_pm.c
+++ b/usr/hp_ultrium_pm.c
@@ -48,10 +48,10 @@
 #include "mhvtl_log.h"
 
 static struct density_info density_lto1 = {
-	4880, 127, 384, 10000, medium_density_code_lto1,
+	4880, 127, 384, 100000, medium_density_code_lto1,
 			"LTO-CVE", "U-18", "Ultrium 1/8T" };
 static struct density_info density_lto2 = {
-	4880, 127, 512, 20000, medium_density_code_lto2,
+	4880, 127, 512, 200000, medium_density_code_lto2,
 			"LTO-CVE", "U-28", "Ultrium 2/8T" };
 static struct density_info density_lto3 = {
 	9638, 127, 704, 381469, medium_density_code_lto3,

--- a/usr/ult3580_pm.c
+++ b/usr/ult3580_pm.c
@@ -48,10 +48,10 @@
 #include "mhvtl_log.h"
 
 static struct density_info density_lto1 = {
-	4880, 127, 384, 10000, medium_density_code_lto1,
+	4880, 127, 384, 100000, medium_density_code_lto1,
 			"LTO-CVE", "U-18", "Ultrium 1/8T" };
 static struct density_info density_lto2 = {
-	4880, 127, 512, 20000, medium_density_code_lto2,
+	4880, 127, 512, 200000, medium_density_code_lto2,
 			"LTO-CVE", "U-28", "Ultrium 2/8T" };
 static struct density_info density_lto3 = {
 	9638, 127, 704, 381469, medium_density_code_lto3,


### PR DESCRIPTION
Hi Mark,

I noticed in the PR you pushed about 1 hour ago the same issue exists for LTO1 and LTO2. This PR fixes those tapes in the identical way to commit ff898da.

Thanks for all your work and I hope you are enjoying retirement.
