### PR TITLE
Updates for ubuntu

### DIFF
--- a/kernel/.gitignore
+++ b/kernel/.gitignore
@@ -1,1 +1,3 @@
 TAGS
+*.cmd
+*.mod

--- a/kernel/config.sh
+++ b/kernel/config.sh
@@ -141,7 +141,7 @@ fi >> "${output}"
 pat='int (*match)(struct device *dev, const struct device_driver *drv);'
 
 # First, find the file
-bus_type_def_file=$(grep -rl 'struct bus_type {' ${hdrs})
+bus_type_def_file=$(grep -Rl 'struct bus_type {' ${hdrs})
 : {bus_type_def_file:="not-found"}
 
 # Now check for the 2nd argument needs a "const"

--- a/usr/ssc.c
+++ b/usr/ssc.c
@@ -1631,7 +1631,8 @@ uint8_t ssc_read_position(struct scsi_cmd *cmd)
 	case TAPE_LOADED:
 		switch (service_action) {
 		case 0:
-			sp = (struct read_position_information_short *)&buf[0];
+		case 1:
+		sp = (struct read_position_information_short *)&buf[0];
 
 			memset(buf, 0, READ_POSITION_LEN);	/* Clear 'array' */
 

--- a/usr/vtltape.c
+++ b/usr/vtltape.c
@@ -1728,7 +1728,7 @@ static int processMessageQ(struct q_msg *msg, uint8_t *sam_stat)
 		if (lu_ssc.barcode) {
 			free(lu_ssc.barcode);
 		}
-		lu_ssc.barcode = malloc(strlen(pcl) + 1);
+		lu_ssc.barcode = malloc(pcl_len);
 		if (lu_ssc.barcode) {
 			strncpy(lu_ssc.barcode, pcl, pcl_len);
 			set_lp11_medium_present(1);


### PR DESCRIPTION
I compiled the kernel module and daemons on Ubuntu 24.04 with kernel 6.8.0-90-generic.

To allow the kernel module to compile, I had to change an option on the grep command to ensure it properly de-references softlinks and finds the files it's looking for. Apparently the way kernel source is packaged on Ubuntu causes it to appear with a litany of softlinks, and the grep command needs to follow those when doing the recursive grep.

I ran into a segmentation fault in the vtltape daemon. On line 1716, pcl_len is calculated as strlen(pcl) + 2. However, on line 1731 only strlen(pcl)+1bytes are allocated, and on line 1733 pcl_len bytes are copied - 1 more than allocated. When I change the malloc to allocate pcl_len bytes, the segv no longer occurs.

One of my ancient software packages does a read position call to the tape daemon with service action 1. However, only service actions 0 and 6 are supported in the case statement, so it would always fail. As is stated on line 1624, service action 0 and 1 should return a short response, so I added a case for service action 1 which does the same thing as what was already implemented for service action 0. That made my software package happy and didn't seem to have any negative effects.