### PR TITLE
kernel: use GFP_KERNEL for ioctl-path slab allocations

### DIFF
--- a/kernel/fetch27.c
+++ b/kernel/fetch27.c
@@ -29,7 +29,7 @@ static size_t mhvtl_sg_copy_user(struct scatterlist *sgl, unsigned int nents,
 		sg_flags |= SG_MITER_TO_SG;
 #endif
 
-	kmem_user = kmem_cache_alloc(sgp, 0);
+	kmem_user = kmem_cache_alloc(sgp, GFP_KERNEL);
 	if (!kmem_user)
 		return offset;
 

--- a/kernel/fetch50.c
+++ b/kernel/fetch50.c
@@ -30,7 +30,7 @@ static size_t mhvtl_sg_copy_user(struct scatterlist *sgl, unsigned int nents,
 		sg_flags |= SG_MITER_TO_SG;
 #endif
 
-	kmem_user = kmem_cache_alloc(sgp, 0);
+	kmem_user = kmem_cache_alloc(sgp, GFP_KERNEL);
 	if (!kmem_user)
 		return offset;
 

--- a/kernel/mhvtl.c
+++ b/kernel/mhvtl.c
@@ -1487,7 +1487,7 @@ static int mhvtl_get_user_data(unsigned int minor, char __user *arg) {
 	unsigned char __user	*up;
 	size_t					 sz;
 
-	ds = kmem_cache_alloc(dsp, 0);
+	ds = kmem_cache_alloc(dsp, GFP_KERNEL);
 	if (!ds)
 		return -EFAULT;
 
@@ -1522,7 +1522,7 @@ static int mhvtl_put_user_data(unsigned int minor, char __user *arg) {
 	int						 ret = 0;
 	uint8_t					*s;
 
-	ds = kmem_cache_alloc(dsp, 0);
+	ds = kmem_cache_alloc(dsp, GFP_KERNEL);
 	if (!ds) {
 		pr_err("Failed to allocate kmem_cache\n");
 		ret = -EFAULT;


### PR DESCRIPTION
On Linux 6.x and newer the slab allocator rejects kmem_cache_alloc() calls with gfp=0, leading to SLUB allocation failures in mhvtl's ioctl data-transfer path:

  SLUB: Unable to allocate memory on CPU N, gfp=0x0()
  cache: mhvtl_sg_cache, ...

The truncated buffer makes the kernel return a 5-byte INQUIRY stub to the SCSI mid-layer (peripheral_device_type=0), so every mhvtl LU appears as a generic disk with empty vendor/product strings instead of the configured tape or medium changer.

All four affected callers run in ioctl/process context and may sleep (one explicitly calls copy_from_user right after the allocation), so GFP_KERNEL is the correct flag.

Tested on Linux (Proxmox) kernel 7.0.2-6-pve with vtltape/vtllibrary 1.8.0: after the patch INQUIRY responses arrive in full length, device types report as Sequential-Access (1) and Medium-Changer (8), and /dev/st0 plus /dev/sch0 are created as expected.