### PR TITLE
MAM: make the volume coherency information usable

### DIFF
--- a/include/ssc.h
+++ b/include/ssc.h
@@ -159,6 +159,9 @@ struct priv_lu_ssc {
 	int		   *OK_2_write;
 	struct MAM *mamp;
 
+	/* Set once the volume change reference has been bumped for this load */
+	uint8_t vcr_updated;
+
 	uint64_t allow_overwrite_block; /* Used by 'allow overwrite' op code */
 	uint64_t max_capacity;			/* save MAM.max_capacity here for quick access */
 	uint64_t bytesRead_M;			/* Bytes read from media */

--- a/include/vtllib.h
+++ b/include/vtllib.h
@@ -151,6 +151,15 @@ struct mode {
  */
 #define MAM_VERSION 4
 
+/* Length of the VOLUME COHERENCY INFORMATION attribute (0x080c).
+ * SSC defines this as 0x46 bytes: a one byte VCR length, the 8 byte volume
+ * change reference, an 8 byte coherency count, an 8 byte coherency set
+ * identifier, a two byte application client specific information length
+ * followed by 43 bytes of that information (LTFS stores "LTFS", the volume
+ * uuid and a format version byte there).
+ */
+#define MAM_COHERENCY_LEN 0x46
+
 enum MAM_attribute_idx {
 	/* 0x0000 – 0x03ff : Device */
 	MAM_REMAINING_CAPACITY,
@@ -213,6 +222,14 @@ enum MHVTL_attribute_idx {
 	MAM_MHVTL_MAX_PARTITIONS,
 	MAM_MHVTL_NUM_PARTITIONS,
 	MAM_MHVTL_MEDIA_TYPE,
+
+	/* Volume coherency information for partitions 1 and up. Partition 0 is
+	 * carried by the standard 0x080c attribute, but the coherency record is
+	 * per-partition and only one of them fits in the SSC attribute space.
+	 */
+	MAM_MHVTL_VOLUME_COHERENCY_P1,
+	MAM_MHVTL_VOLUME_COHERENCY_P2,
+	MAM_MHVTL_VOLUME_COHERENCY_P3,
 
 	/* media_info */
 	MAM_MHVTL_MEDIAINFO_BITS_PER_MM,
@@ -286,7 +303,7 @@ struct MAM {
 	uint8_t OwningHostTextualName[80];
 	uint8_t MediaPool[160];
 	uint8_t ApplicationFormatVersion[16];
-	uint8_t VolumeCoherencyInformation[46];
+	uint8_t VolumeCoherencyInformation[MAX_PARTITIONS][MAM_COHERENCY_LEN];
 
 	/* 0x0c00 - 0x0fff - Device - Vendor Specific */
 	/* 0x1000 - 0x13ff - Medium - Vendor Specific */

--- a/usr/cmd/vtltape.c
+++ b/usr/cmd/vtltape.c
@@ -383,6 +383,22 @@ int resp_report_density(struct priv_lu_ssc *lu_priv, uint8_t media,
 }
 
 /*
+ * Where the value of a MAM attribute lives for a given partition.
+ *
+ * Almost every attribute describes the whole medium, so the partition number
+ * in the CDB makes no difference. The volume coherency information (0x080c) is
+ * the exception - it records where the last index was written, which is per
+ * partition - so it is kept as one record per partition and selected here.
+ */
+static void *mam_attr_value(int indx, uint8_t partition) {
+	if ((mam.attributes[indx].attribute_id == 0x80c) &&
+		(partition < MAX_PARTITIONS))
+		return mam.VolumeCoherencyInformation[partition];
+
+	return mam.attributes[indx].value;
+}
+
+/*
  * Read Attribute
  *
  * Fill in 'buf' with data and return number of bytes
@@ -425,7 +441,8 @@ int resp_read_attribute(struct scsi_cmd *cmd) {
 					buf[byte_index++] = (mam.attributes[indx].read_only << 7) | mam.attributes[indx].format;
 					buf[byte_index++] = mam.attributes[indx].length >> 8;
 					buf[byte_index++] = mam.attributes[indx].length;
-					memcpy(&buf[byte_index], mam.attributes[indx].value, mam.attributes[indx].length);
+					memcpy(&buf[byte_index], mam_attr_value(indx, cdb[7]),
+						   mam.attributes[indx].length);
 					byte_index += mam.attributes[indx].length;
 				}
 			}
@@ -500,9 +517,16 @@ int resp_write_attribute(struct scsi_cmd *cmd) {
 					MHVTL_LOG("Converted media to WORM");
 					mamp->MediumType = MEDIA_TYPE_WORM;
 				} else {
-					memcpy(mam.attributes[indx].value,
+					/* Never take more than the initiator sent, nor more
+					 * than the field can hold.
+					 */
+					uint16_t len = mam.attributes[indx].length;
+					if (len > attribute_length)
+						len = attribute_length;
+
+					memcpy(mam_attr_value(indx, cdb[7]),
 						   &buf[byte_index],
-						   mam.attributes[indx].length);
+						   len);
 				}
 				byte_index += attribute_length; /* Positioning to the next attribute if any */
 				break;
@@ -960,7 +984,11 @@ static void updateMAM(uint8_t *sam_stat, int load) {
 	/* Update on load */
 	if (load) {
 		mam.record_dirty = 1;
-		load_count		 = get_unaligned_be64(&mam.LoadCount);
+		/* The volume change reference is bumped once per load, by the first
+		 * command which modifies the medium.
+		 */
+		lu_ssc.vcr_updated = 0;
+		load_count		   = get_unaligned_be64(&mam.LoadCount);
 		load_count++;
 		put_unaligned_be64(load_count, &mam.LoadCount);
 

--- a/usr/ssc.c
+++ b/usr/ssc.c
@@ -73,6 +73,43 @@ void memset_ssc_buf(struct scsi_cmd *cmd, uint64_t alloc_len) {
 	memset(buf, 0, min((int)alloc_len, lu_priv->bufsize));
 }
 
+/*
+ * Update the Volume Change Reference (MAM attribute 0x0009)
+ *
+ * SSC has the drive change this value whenever the contents of the medium
+ * change. Applications which cache index information in the MAM coherency
+ * attribute (0x080c) - LTFS being the obvious one - store the VCR next to the
+ * position of the last index they wrote, then compare it against the current
+ * VCR when the medium is mounted again. Same value means nothing has written
+ * to the medium since, so the recorded index position can be trusted and a
+ * full scan of the medium skipped.
+ *
+ * A VCR of zero, or of all ones, means 'not available' and makes every
+ * coherency record on the medium worthless.
+ *
+ * The value is bumped once per load, by the first command which modifies the
+ * medium, and then left alone for the rest of the session. That ordering
+ * matters: the coherency record is written after the data it describes, so the
+ * VCR it captures has to be the one still in place at the next load.
+ */
+static void update_volume_change_reference(struct priv_lu_ssc *lu_priv, uint8_t *sam_stat) {
+	uint32_t vcr;
+
+	if (lu_priv->vcr_updated)
+		return;
+
+	vcr = get_unaligned_be32(&lu_priv->mamp->VolumeChangeReference) + 1;
+	if (!vcr) /* zero is reserved for 'not available' */
+		vcr = 1;
+
+	put_unaligned_be32(vcr, &lu_priv->mamp->VolumeChangeReference);
+	lu_priv->vcr_updated = 1;
+
+	MHVTL_DBG(2, "Volume change reference is now %u", vcr);
+
+	rewriteMAM(sam_stat);
+}
+
 uint8_t ssc_allow_overwrite(struct scsi_cmd *cmd) {
 	declare_ssc_vars;
 
@@ -396,6 +433,8 @@ uint8_t ssc_write_6(struct scsi_cmd *cmd) {
 		return SAM_STAT_CHECK_CONDITION;
 
 	if (OK_to_write) {
+		update_volume_change_reference(lu_priv, sam_stat);
+
 		for (k = 0; k < count; k++) {
 			retval = writeBlock(cmd, sz);
 			buf += retval;
@@ -582,6 +621,8 @@ uint8_t ssc_format_medium(struct scsi_cmd *cmd) {
 		sam_illegal_request(E_POSITION_PAST_BOM, NULL, sam_stat);
 		return SAM_STAT_CHECK_CONDITION;
 	}
+
+	update_volume_change_reference(lu_priv, sam_stat);
 
 	/* 0h = format the volume to a single partition */
 	/* 1h = use medium partition mode page to format the partitions */
@@ -1650,9 +1691,10 @@ uint8_t ssc_erase(struct scsi_cmd *cmd) {
 		return SAM_STAT_CHECK_CONDITION;
 	}
 
-	if (OK_to_write)
+	if (OK_to_write) {
+		update_volume_change_reference(lu_priv, sam_stat);
 		format_partition(sam_stat);
-	else {
+	} else {
 		MHVTL_LOG("Attempt to erase Write-protected media");
 		sam_not_ready(E_MEDIUM_OVERWRITE_ATTEMPT, sam_stat);
 	}
@@ -1851,6 +1893,9 @@ uint8_t ssc_write_filemarks(struct scsi_cmd *cmd) {
 		} else
 			return SAM_STAT_CHECK_CONDITION;
 	}
+
+	if (count) /* A count of zero is a buffer flush, not a change of content */
+		update_volume_change_reference(lu_priv, sam_stat);
 
 	write_filemarks(count, sam_stat);
 	if (count) {

--- a/usr/vtlcart.c
+++ b/usr/vtlcart.c
@@ -646,11 +646,23 @@ int read_mam(int mam_fd, int mhvtl_fd, struct MAM *mamp) {
 				continue;
 			}
 
-			if (read(mam_fd, mamp->attributes[idx].value, attr.length) != attr.length) {
+			/* The length stored on the medium need not match the length
+			 * this build expects - an attribute may have grown or shrunk
+			 * between mhvtl versions. Take only what fits the field and
+			 * step over whatever is left of the stored value.
+			 */
+			uint16_t len = attr.length;
+			if (len > mamp->attributes[idx].length)
+				len = mamp->attributes[idx].length;
+
+			if (read(mam_fd, mamp->attributes[idx].value, len) != len) {
 				MHVTL_ERR("Error reading mam attribute %04x value : %s",
 						  attr.attribute_id, strerror(errno));
 				return -1;
 			}
+
+			if (attr.length > len)
+				lseek(mam_fd, attr.length - len, SEEK_CUR);
 		}
 	}
 
@@ -685,11 +697,18 @@ int read_mam(int mam_fd, int mhvtl_fd, struct MAM *mamp) {
 				continue;
 			}
 
-			if (read(mhvtl_fd, mamp->mhvtl_attr[idx].value, attr.length) != attr.length) {
+			uint16_t len = attr.length;
+			if (len > mamp->mhvtl_attr[idx].length)
+				len = mamp->mhvtl_attr[idx].length;
+
+			if (read(mhvtl_fd, mamp->mhvtl_attr[idx].value, len) != len) {
 				MHVTL_ERR("Error reading mhvtl attribute %04x value : %s",
 						  attr.attribute_id, strerror(errno));
 				return -1;
 			}
+
+			if (attr.length > len)
+				lseek(mhvtl_fd, attr.length - len, SEEK_CUR);
 		}
 	}
 

--- a/usr/vtllib.c
+++ b/usr/vtllib.c
@@ -140,7 +140,7 @@ void init_mam(struct MAM *mamp) {
 	INIT_MAM_ATTR(0x807, 80, 0, 2, mamp->OwningHostTextualName, MAM_OWNING_HOST_TEXTUAL_NAME);
 	INIT_MAM_ATTR(0x808, 160, 0, 2, mamp->MediaPool, MAM_MEDIA_POOL);
 	INIT_MAM_ATTR(0x80b, 16, 0, 1, mamp->ApplicationFormatVersion, MAM_APPLICATION_FORMAT_VERSION);
-	INIT_MAM_ATTR(0x80c, 46, 0, 0, mamp->VolumeCoherencyInformation, MAM_VOLUME_COHERENCY_INFORMATION);
+	INIT_MAM_ATTR(0x80c, MAM_COHERENCY_LEN, 0, 0, mamp->VolumeCoherencyInformation[0], MAM_VOLUME_COHERENCY_INFORMATION);
 
 	/* 0x0c00 - 0x0fff - Device - Vendor Specific */
 	/* 0x1000 - 0x13ff - Medium - Vendor Specific */
@@ -155,7 +155,14 @@ void init_mam(struct MAM *mamp) {
 	INIT_VTL_ATTR(0x02, 2, mamp->Flags, MAM_MHVTL_FLAGS);
 	INIT_VTL_ATTR(0x03, 1, mamp->max_partitions, MAM_MHVTL_MAX_PARTITIONS);
 	INIT_VTL_ATTR(0x04, 1, mamp->num_partitions, MAM_MHVTL_NUM_PARTITIONS);
-	INIT_VTL_ATTR(0x05, 1, mamp->MediaType, MAM_MHVTL_NUM_PARTITIONS);
+	INIT_VTL_ATTR(0x05, 1, mamp->MediaType, MAM_MHVTL_MEDIA_TYPE);
+
+	/* Coherency information for the remaining partitions. Kept as mhvtl
+	 * private attributes so each partition gets its own record.
+	 */
+	INIT_VTL_ATTR(0x0a, MAM_COHERENCY_LEN, mamp->VolumeCoherencyInformation[1], MAM_MHVTL_VOLUME_COHERENCY_P1);
+	INIT_VTL_ATTR(0x0b, MAM_COHERENCY_LEN, mamp->VolumeCoherencyInformation[2], MAM_MHVTL_VOLUME_COHERENCY_P2);
+	INIT_VTL_ATTR(0x0c, MAM_COHERENCY_LEN, mamp->VolumeCoherencyInformation[3], MAM_MHVTL_VOLUME_COHERENCY_P3);
 
 	INIT_VTL_ATTR(0x06, 4, mamp->media_info.bits_per_mm, MAM_MHVTL_MEDIAINFO_BITS_PER_MM);
 	INIT_VTL_ATTR(0x07, 2, mamp->media_info.tracks, MAM_MHVTL_MEDIAINFO_TRACKS);


### PR DESCRIPTION
LTFS records the position of the last index it wrote in the volume coherency information attribute (0x080c) and validates it against the volume change reference (0x0009) when mounting a volume. Neither of them worked, so every mount fell back to scanning the whole medium:

  LTFS11015W VCR MAM parameter is not usable.
  LTFS11016W The index partition MAM parameter is not usable.
  LTFS11017W The data partition MAM parameter is not usable.
  LTFS11026I Performing a full medium consistency check.

Three separate problems, each sufficient on its own:

- The volume change reference was never updated, so it always read back as zero. SSC defines zero as "not available", and LTFS in turn returns from ltfs_update_cart_coherency() without storing anything when it sees that, so no coherency record was ever written in the first place. It is now bumped once per load, by the first command which modifies the medium - write, write filemarks, erase or format - and then left alone for the rest of the session. That ordering matters: the coherency record is written after the data it describes, so the value it captures has to be the one still in place at the next load. A load or unload on its own must not change it, or the record would be stale every time.

- The attribute was 46 bytes where SSC defines 0x46 (70). LTFS places the volume uuid at offset 32..68 of the value and a format version byte at offset 69, so the record was truncated mid-uuid and lost the version byte entirely. The uuid comparison at mount time then fails even when the volume change reference is valid.

- A single record was shared by every partition. The coherency information describes where the last index was written, which is per partition, so reading it back for the index partition returned the data partition's position. Each partition now keeps its own record: partition 0 stays in the standard attribute, the remainder are held as mhvtl private attributes, and READ/WRITE ATTRIBUTE select between them using the partition number from the CDB.

read_mam() now clamps each stored value to the size of the field it is read into and steps over any remainder, so media written by either the old or the new code load correctly - and a bogus length in the file can no longer overrun the struct. This is what keeps MAM_VERSION at 4: bumping it would send every existing cartridge through try_update_mam(), which only knows how to convert version 3 and rejects anything else as E_MEDIUM_FMT_CORRUPT.

resp_write_attribute() takes the smaller of the length the initiator sent and the size of the target field, instead of always copying the field size, which over-read the parameter buffer when an initiator sent a short value.

Also fixes an INIT_VTL_ATTR() call which passed MAM_MHVTL_NUM_PARTITIONS as the index for the media type, overwriting the num_partitions entry so that attribute 0x04 was never persisted. Harmless in practice, since load_tape() recounts partitions from the data.N files, but it left an empty attribute slot behind.

Verified against ltfs 2.4.8.4 and an emulated IBM ULT3580-TD6: mkltfs, mount, write, unmount, remount, and a full unload/reload cycle through the changer all mount from the MAM records with no warnings and no full medium scan. The index and data partitions report different index positions as expected, the volume change reference survives load cycles unchanged and increments on the next session which writes, and the 70-byte record round-trips with the complete uuid and version byte intact.

Co-authored by Claude