### PR TITLE
fix: report and enforce capacity, partitioning and end of medium

### DIFF
--- a/include/vtlcart.h
+++ b/include/vtlcart.h
@@ -223,6 +223,7 @@ int		 write_mam(int mam_fd, int mhvtl_fd);
 int		 read_mam(int mam_fd, int mhvtl_fd, struct MAM *mamp);
 int		 rewriteMAM(uint8_t *sam_stat);
 uint64_t current_tape_offset(void);
+uint64_t partition_data_offset(int partition);
 uint64_t current_tape_block(void);
 uint64_t last_block(uint8_t partition_number);
 uint64_t block_from_filemark(uint8_t partition_number, uint32_t filemark);

--- a/include/vtllib.h
+++ b/include/vtllib.h
@@ -772,6 +772,7 @@ int add_drive_media_list(struct lu_phy_attr *lu, int status, char *s);
 
 void		 find_media_home_directory(char *config_directory, long lib_id);
 unsigned int set_media_params(struct MAM *mamp, char *density);
+uint8_t		 media_max_partitions(uint8_t media_type);
 uint64_t	 media_native_capacity(uint8_t media_type);
 uint64_t	 media_mam_capacity(uint8_t media_type);
 void		 mam_space_remaining(struct MAM *mamp);

--- a/include/vtllib.h
+++ b/include/vtllib.h
@@ -231,6 +231,12 @@ enum MHVTL_attribute_idx {
 	MAM_MHVTL_VOLUME_COHERENCY_P2,
 	MAM_MHVTL_VOLUME_COHERENCY_P3,
 
+	/* Size of each partition, written at format time */
+	MAM_MHVTL_PARTITION_CAPACITY_P0,
+	MAM_MHVTL_PARTITION_CAPACITY_P1,
+	MAM_MHVTL_PARTITION_CAPACITY_P2,
+	MAM_MHVTL_PARTITION_CAPACITY_P3,
+
 	/* media_info */
 	MAM_MHVTL_MEDIAINFO_BITS_PER_MM,
 	MAM_MHVTL_MEDIAINFO_TRACKS,
@@ -316,6 +322,14 @@ struct MAM {
 	uint8_t	 MediaType; /* LTO1, LTO2, AIT etc (Media_Type_list) */
 	uint8_t	 max_partitions;
 	uint8_t	 num_partitions;
+
+	/* Capacity of each partition in bytes, as laid down when the medium was
+	 * formatted. Partitioning belongs to the medium - a real drive reads the
+	 * geometry back off the tape when a cartridge is loaded - so it has to
+	 * outlive the drive it was formatted in. Zero for media formatted before
+	 * this was recorded, or never partitioned.
+	 */
+	uint64_t partition_capacity[MAX_PARTITIONS];
 
 	struct uniq_media_info {
 		uint32_t bits_per_mm;
@@ -693,6 +707,8 @@ uint32_t	 resp_read_media_serial(uint8_t *, uint8_t *, uint8_t *);
 int			 resp_mode_sense(uint8_t *, uint8_t *, struct mode *, uint8_t, uint8_t *);
 struct mode *lookup_mode_pg(struct list_head *l, uint8_t pcode, uint8_t subpcode);
 uint64_t	 medium_partition_capacity(struct lu_phy_attr *lu, int partition);
+uint64_t	 medium_partition_capacity_from_mode_page(struct lu_phy_attr *lu, int partition);
+void		 set_medium_partition_capacity(struct lu_phy_attr *lu);
 int			 resp_read_block_limits(struct mhvtl_ds *dbuf_p, int sz);
 
 void  hex_dump(uint8_t *, int);

--- a/include/vtllib.h
+++ b/include/vtllib.h
@@ -692,6 +692,7 @@ int			 resp_read_position(loff_t, uint8_t *, uint8_t *);
 uint32_t	 resp_read_media_serial(uint8_t *, uint8_t *, uint8_t *);
 int			 resp_mode_sense(uint8_t *, uint8_t *, struct mode *, uint8_t, uint8_t *);
 struct mode *lookup_mode_pg(struct list_head *l, uint8_t pcode, uint8_t subpcode);
+uint64_t	 medium_partition_capacity(struct lu_phy_attr *lu, int partition);
 int			 resp_read_block_limits(struct mhvtl_ds *dbuf_p, int sz);
 
 void  hex_dump(uint8_t *, int);
@@ -754,6 +755,9 @@ int add_drive_media_list(struct lu_phy_attr *lu, int status, char *s);
 
 void		 find_media_home_directory(char *config_directory, long lib_id);
 unsigned int set_media_params(struct MAM *mamp, char *density);
+uint64_t	 media_native_capacity(uint8_t media_type);
+uint64_t	 media_mam_capacity(uint8_t media_type);
+void		 mam_space_remaining(struct MAM *mamp);
 
 char *slot_type_str(int type);
 void  init_smc_log_pages(struct lu_phy_attr *lu);

--- a/include/vtllib.h
+++ b/include/vtllib.h
@@ -709,6 +709,7 @@ struct mode *lookup_mode_pg(struct list_head *l, uint8_t pcode, uint8_t subpcode
 uint64_t	 medium_partition_capacity(struct lu_phy_attr *lu, int partition);
 uint64_t	 medium_partition_capacity_from_mode_page(struct lu_phy_attr *lu, int partition);
 void		 set_medium_partition_capacity(struct lu_phy_attr *lu);
+void		 update_medium_partition_page(struct lu_phy_attr *lu);
 int			 resp_read_block_limits(struct mhvtl_ds *dbuf_p, int sz);
 
 void  hex_dump(uint8_t *, int);

--- a/usr/cmd/edit_tape.c
+++ b/usr/cmd/edit_tape.c
@@ -265,6 +265,14 @@ int main(int argc, char *argv[]) {
 		 * Usage, this will be recalculated correctly
 		 */
 		put_unaligned_be64(size * 1048576, &new_mam.remaining_capacity);
+	} else if (mediaCapacity) {
+		/* '-s 0' asks for the native capacity of the media type */
+		uint64_t native = media_native_capacity(new_mam.MediaType);
+
+		printf("Using native capacity for %s: %" PRIu64 "MB\n",
+			   pcl, native >> 20);
+		put_unaligned_be64(native, &new_mam.max_capacity);
+		put_unaligned_be64(native, &new_mam.remaining_capacity);
 	}
 	switch (wp) {
 	case WRITE_PROTECT_ON:
@@ -277,7 +285,7 @@ int main(int argc, char *argv[]) {
 		break;
 	}
 
-	put_unaligned_be64(new_mam.max_capacity - sizeof(struct MAM), &new_mam.MAMSpaceRemaining);
+	mam_space_remaining(&new_mam);
 
 	memcpy(&mam, &new_mam, sizeof(mam));
 	rewriteMAM(&sam_stat);

--- a/usr/cmd/mktape.c
+++ b/usr/cmd/mktape.c
@@ -157,9 +157,10 @@ int main(int argc, char *argv[]) {
 		exit(1);
 	}
 
+	/* A size of zero asks for the native capacity of the media type, which
+	 * set_media_params() fills in once the density is known.
+	 */
 	sscanf(mediaCapacity, "%" PRId64, &size);
-	if (size == 0)
-		size = 8000;
 
 	sscanf(lib, "%d", &libno);
 	if (!libno) {
@@ -189,9 +190,12 @@ int main(int argc, char *argv[]) {
 
 	mam.tape_fmt_version = TAPE_FMT_VERSION;
 	mam.mam_fmt_version	 = MAM_VERSION;
+
+	/* A size of zero leaves the capacity to set_media_params(), which fills in
+	 * whatever the media type natively holds.
+	 */
 	put_unaligned_be64(size * 1048576, &mam.max_capacity);
 	put_unaligned_be64(size * 1048576, &mam.remaining_capacity);
-	put_unaligned_be64(mam.max_capacity - sizeof(struct MAM), &mam.MAMSpaceRemaining);
 
 	memcpy(&mam.MediumManufacturer, "linuxVTL", 8);
 	memcpy(&mam.ApplicationVendor, &ver, 8);
@@ -207,7 +211,19 @@ int main(int argc, char *argv[]) {
 	} else {
 		mam.MediumType = MEDIA_TYPE_DATA; /* Normal data cart */
 	}
-	set_media_params(&mam, density);
+	/* Without a recognised density there is no media type, and so no capacity
+	 * to give the cartridge - refuse rather than write out unusable media.
+	 */
+	if (set_media_params(&mam, density)) {
+		fprintf(stderr, "error: '%s' is not a density this build knows\n",
+				density);
+		exit(1);
+	}
+
+	/* Space left in the cartridge memory, being what the attributes stored in
+	 * it do not already take up.
+	 */
+	mam_space_remaining(&mam);
 
 	sprintf((char *)mam.MediumSerialNumber, "%s_%d", pcl, (int)gettime());
 	sprintf((char *)mam.MediumManufactureDate, "%d", (int)gettime());

--- a/usr/cmd/vtltape.c
+++ b/usr/cmd/vtltape.c
@@ -385,15 +385,42 @@ int resp_report_density(struct priv_lu_ssc *lu_priv, uint8_t media,
 /*
  * Where the value of a MAM attribute lives for a given partition.
  *
- * Almost every attribute describes the whole medium, so the partition number
- * in the CDB makes no difference. The volume coherency information (0x080c) is
- * the exception - it records where the last index was written, which is per
- * partition - so it is kept as one record per partition and selected here.
+ * Most attributes describe the whole medium, so the partition number in the CDB
+ * makes no difference and the value is returned straight out of the MAM.
+ *
+ * Two kinds of attribute are per-partition and handled here:
+ *
+ * - The volume coherency information (0x080c) records where the last index was
+ *   written, so one record is kept per partition.
+ *
+ * - The remaining and maximum capacity (0x0000 and 0x0001) describe one
+ *   partition each, and SSC specifies them in megabytes where the MAM holds
+ *   capacities in bytes. Both are built into 'scratch', which the caller
+ *   supplies and which must be at least eight bytes.
  */
-static void *mam_attr_value(int indx, uint8_t partition) {
-	if ((mam.attributes[indx].attribute_id == 0x80c) &&
-		(partition < MAX_PARTITIONS))
-		return mam.VolumeCoherencyInformation[partition];
+static void *mam_attr_value(struct lu_phy_attr *lu, int indx, uint8_t partition,
+							uint8_t *scratch) {
+	uint64_t cap, used;
+
+	switch (mam.attributes[indx].attribute_id) {
+	case 0x000: /* Remaining capacity in partition */
+		cap	 = medium_partition_capacity(lu, partition);
+		used = partition_data_offset(partition);
+		put_unaligned_be64((used < cap) ? (cap - used) >> 20 : 0, scratch);
+		return scratch;
+
+	case 0x001: /* Maximum capacity in partition */
+		put_unaligned_be64(medium_partition_capacity(lu, partition) >> 20, scratch);
+		return scratch;
+
+	case 0x80c: /* Volume coherency information */
+		if (partition < MAX_PARTITIONS)
+			return mam.VolumeCoherencyInformation[partition];
+		break;
+
+	default:
+		break;
+	}
 
 	return mam.attributes[indx].value;
 }
@@ -413,6 +440,7 @@ int resp_read_attribute(struct scsi_cmd *cmd) {
 	unsigned int byte_index = 4;
 	int			 indx, found_attribute;
 	struct s_sd	 sd;
+	uint8_t		 scratch[8]; /* Holds values which are computed per partition */
 
 	attrib	  = get_unaligned_be16(&cdb[8]);
 	alloc_len = get_unaligned_be32(&cdb[10]);
@@ -441,7 +469,8 @@ int resp_read_attribute(struct scsi_cmd *cmd) {
 					buf[byte_index++] = (mam.attributes[indx].read_only << 7) | mam.attributes[indx].format;
 					buf[byte_index++] = mam.attributes[indx].length >> 8;
 					buf[byte_index++] = mam.attributes[indx].length;
-					memcpy(&buf[byte_index], mam_attr_value(indx, cdb[7]),
+					memcpy(&buf[byte_index],
+						   mam_attr_value(cmd->lu, indx, cdb[7], scratch),
 						   mam.attributes[indx].length);
 					byte_index += mam.attributes[indx].length;
 				}
@@ -494,6 +523,7 @@ int resp_write_attribute(struct scsi_cmd *cmd) {
 	unsigned int byte_index = 4;
 	int			 indx, found_attribute;
 	struct s_sd	 sd;
+	uint8_t		 scratch[8];
 
 	alloc_len = get_unaligned_be32(&cdb[10]);
 	attrib	  = get_unaligned_be16(&buf[byte_index]);
@@ -517,6 +547,17 @@ int resp_write_attribute(struct scsi_cmd *cmd) {
 					/* set media to worm */
 					MHVTL_LOG("Converted media to WORM");
 					mamp->MediumType = MEDIA_TYPE_WORM;
+				} else if (mam.attributes[indx].read_only) {
+					/* Device and medium attributes belong to the drive and
+					 * the cartridge, and cannot be written by an initiator.
+					 */
+					MHVTL_DBG(1, "Attribute 0x%04x is read only", attrib);
+					memcpy(mamp, &mam_backup, sizeof(struct MAM));
+					sd.byte0		 = SKSV;
+					sd.field_pointer = byte_index - 5;
+					sam_illegal_request(E_INVALID_FIELD_IN_PARMS, &sd,
+										sam_stat);
+					return 0;
 				} else {
 					/* Never take more than the initiator sent, nor more
 					 * than the field can hold.
@@ -525,7 +566,7 @@ int resp_write_attribute(struct scsi_cmd *cmd) {
 					if (len > attribute_length)
 						len = attribute_length;
 
-					memcpy(mam_attr_value(indx, cdb[7]),
+					memcpy(mam_attr_value(cmd->lu, indx, cdb[7], scratch),
 						   &buf[byte_index],
 						   len);
 				}
@@ -537,7 +578,7 @@ int resp_write_attribute(struct scsi_cmd *cmd) {
 			}
 		}
 		if (!found_attribute) {
-			memcpy(&mamp, &mam_backup, sizeof(mamp));
+			memcpy(mamp, &mam_backup, sizeof(struct MAM));
 			sd.byte0 = SKSV;
 			sam_illegal_request(E_INVALID_FIELD_IN_PARMS, &sd,
 								sam_stat);
@@ -989,7 +1030,13 @@ static void updateMAM(uint8_t *sam_stat, int load) {
 		 * command which modifies the medium.
 		 */
 		lu_ssc.vcr_updated = 0;
-		load_count		   = get_unaligned_be64(&mam.LoadCount);
+
+		/* Recalculate the cartridge memory usage, which also fills in the
+		 * memory size for media created before it was recorded.
+		 */
+		mam_space_remaining(&mam);
+
+		load_count = get_unaligned_be64(&mam.LoadCount);
 		load_count++;
 		put_unaligned_be64(load_count, &mam.LoadCount);
 

--- a/usr/cmd/vtltape.c
+++ b/usr/cmd/vtltape.c
@@ -1383,6 +1383,12 @@ int loadTape(char *PCL, uint8_t *sam_stat) {
 			  (uint8_t)lu->mode_media_type);
 
 	delay_opcode(DELAY_LOAD, lu_ssc.delay_load);
+	/* The medium has gone from demounted to mounted, which is where SSC has
+	 * the drive set the partition fields of the medium partition mode page
+	 * from the volume now loaded.
+	 */
+	update_medium_partition_page(lu);
+
 	set_current_state(MHVTL_STATE_LOADED);
 	return 0; /* Return successful load */
 

--- a/usr/cmd/vtltape.c
+++ b/usr/cmd/vtltape.c
@@ -1036,6 +1036,12 @@ static void updateMAM(uint8_t *sam_stat, int load) {
 		 */
 		mam_space_remaining(&mam);
 
+		/* How many partitions a cartridge can hold follows from its media
+		 * type, so take it from there rather than from whatever was recorded
+		 * when the medium was created.
+		 */
+		mam.max_partitions = media_max_partitions(mam.MediaType);
+
 		load_count = get_unaligned_be64(&mam.LoadCount);
 		load_count++;
 		put_unaligned_be64(load_count, &mam.LoadCount);

--- a/usr/mhvtl_io.c
+++ b/usr/mhvtl_io.c
@@ -811,7 +811,13 @@ int writeBlock(struct scsi_cmd *cmd, uint32_t src_sz) {
 	if ((lu_priv->pm->drive_supports_early_warning) &&
 		(current_position >= early_warning_position)) {
 		MHVTL_DBG(1, "End of Medium - Early Warning");
-		sam_no_sense(SD_EOM, NO_ADDITIONAL_SENSE, sam_stat);
+		/* Early warning is reported as END-OF-PARTITION/MEDIUM DETECTED with
+		 * the EOM bit, not as an EOM bit on its own: an initiator reading
+		 * ASC/ASCQ 00/00 is told there is nothing to report, and writes on
+		 * until the medium is refused outright - too late to close out a
+		 * filesystem which needs room for a final index.
+		 */
+		sam_no_sense(SD_EOM, E_EOM, sam_stat);
 	} else if ((lu_priv->pm->drive_supports_prog_early_warning) &&
 			   (current_position >= prog_early_warning_position)) {
 		/* FIXME: Need to implement REW bit in Device Configuration Mode Page

--- a/usr/mhvtl_io.c
+++ b/usr/mhvtl_io.c
@@ -722,6 +722,9 @@ int writeBlock(struct scsi_cmd *cmd, uint32_t src_sz) {
 	struct priv_lu_ssc *lu_priv;
 	int					src_len;
 	uint64_t			current_position;
+	uint64_t			partition_capacity;
+	uint64_t			early_warning_position;
+	uint64_t			prog_early_warning_position;
 	int64_t				remaining_capacity;
 	uint8_t			   *sam_stat   = &cmd->dbuf_p->sam_stat;
 	uint32_t			lbp_sz	   = src_sz;
@@ -751,9 +754,16 @@ int writeBlock(struct scsi_cmd *cmd, uint32_t src_sz) {
 		}
 	}
 
-	/* Check if we hit EOT and fail before attempting to write */
-	current_position = current_tape_offset();
-	if (current_position >= lu_priv->max_capacity) {
+	/* Check if we hit EOT and fail before attempting to write.
+	 *
+	 * The limit is the capacity of the partition being written, not of the
+	 * whole medium - otherwise every partition of a partitioned tape believes
+	 * it can hold the entire cartridge.
+	 */
+	partition_capacity = medium_partition_capacity(lu_priv->pm->lu,
+												   c_pos->partition_id);
+	current_position   = current_tape_offset();
+	if (current_position >= partition_capacity) {
 		mam.remaining_capacity = 0L;
 		MHVTL_DBG(1, "End of Medium - VOLUME_OVERFLOW/EOM");
 		sam_no_sense(VOLUME_OVERFLOW | SD_EOM, E_EOM, sam_stat);
@@ -789,19 +799,28 @@ int writeBlock(struct scsi_cmd *cmd, uint32_t src_sz) {
 
 	current_position = current_tape_offset();
 
+	/* Early warning sits a fixed distance from the end of the partition */
+	early_warning_position = (partition_capacity > (uint64_t)lu_priv->early_warning_sz)
+								 ? partition_capacity - lu_priv->early_warning_sz
+								 : 0;
+	prog_early_warning_position =
+		(early_warning_position > (uint64_t)lu_priv->prog_early_warning_sz)
+			? early_warning_position - lu_priv->prog_early_warning_sz
+			: 0;
+
 	if ((lu_priv->pm->drive_supports_early_warning) &&
-		(current_position >= (uint64_t)lu_priv->early_warning_position)) {
+		(current_position >= early_warning_position)) {
 		MHVTL_DBG(1, "End of Medium - Early Warning");
 		sam_no_sense(SD_EOM, NO_ADDITIONAL_SENSE, sam_stat);
 	} else if ((lu_priv->pm->drive_supports_prog_early_warning) &&
-			   (current_position >= (uint64_t)lu_priv->prog_early_warning_position)) {
+			   (current_position >= prog_early_warning_position)) {
 		/* FIXME: Need to implement REW bit in Device Configuration Mode Page
 		 *	  REW == Report Early Warning
 		 */
 		MHVTL_DBG(1, "End of Medium - Programmable Early Warning");
 		sam_no_sense(SD_EOM, E_PROGRAMMABLE_EARLY_WARNING, sam_stat);
 	}
-	remaining_capacity = lu_priv->max_capacity - current_position;
+	remaining_capacity = partition_capacity - current_position;
 	if (remaining_capacity < 0)
 		remaining_capacity = 0L;
 

--- a/usr/mhvtl_log.c
+++ b/usr/mhvtl_log.c
@@ -523,8 +523,8 @@ void update_VolumeStatistics(struct VolumeStatistics_pg *pg, struct priv_lu_ssc 
 		for (i = 0; i < mam.num_partitions; ++i) {
 			struct partition_record_size4 *p_header =
 				((struct partition_record_size4 *)(header + sizeof(struct pc_header))) + i;
-			cap = get_unaligned_be64(&mam.max_capacity) / lu_priv->capacity_unit;
-			put_unaligned_be32(0xfffffffe, &p_header->data);
+			cap = medium_partition_capacity(lu_priv->pm->lu, i) / lu_priv->capacity_unit;
+			put_unaligned_be32(cap, &p_header->data);
 			MHVTL_DBG(1, "approx native capacity for partition %d : %u",
 					  i, get_unaligned_be32(&p_header->data));
 		}
@@ -536,7 +536,8 @@ void update_VolumeStatistics(struct VolumeStatistics_pg *pg, struct priv_lu_ssc 
 	for (i = 0; i < mam.num_partitions; ++i) {
 		struct partition_record_size4 *p_header =
 			((struct partition_record_size4 *)(header + sizeof(struct pc_header))) + i;
-		put_unaligned_be32(0xfffffffe, &p_header->data);
+		cap = partition_data_offset(i) / lu_priv->capacity_unit;
+		put_unaligned_be32(cap, &p_header->data);
 		MHVTL_DBG(1, "approx used native capacity for partition %d : %u",
 				  i, get_unaligned_be32(&p_header->data));
 	}
@@ -548,8 +549,11 @@ void update_VolumeStatistics(struct VolumeStatistics_pg *pg, struct priv_lu_ssc 
 		for (i = 0; i < mam.num_partitions; ++i) {
 			struct partition_record_size4 *p_header =
 				((struct partition_record_size4 *)(header + sizeof(struct pc_header))) + i;
-			cap = get_unaligned_be64(&mam.remaining_capacity) / lu_priv->capacity_unit;
-			put_unaligned_be32(0xfffffffe, &p_header->data);
+			uint64_t part = medium_partition_capacity(lu_priv->pm->lu, i);
+			uint64_t used = partition_data_offset(i) + lu_priv->early_warning_sz;
+
+			cap = (used < part) ? (part - used) / lu_priv->capacity_unit : 0;
+			put_unaligned_be32(cap, &p_header->data);
 			MHVTL_DBG(1, "remaining capacity to EW for partition %d : %u",
 					  i, get_unaligned_be32(&p_header->data));
 		}
@@ -656,16 +660,37 @@ void update_TapeUsage(struct TapeUsage_pg *b) {
 	put_unaligned_be64(datasets, &b->volumeDatasetsWritten);
 }
 
-void update_TapeCapacity(struct TapeCapacity_pg *pg) {
-	uint64_t cap __attribute__((unused)); /* fixme : should be used instead of telling max cap */
-	if (get_tape_load_status() == TAPE_LOADED) {
-		cap = get_unaligned_be64(&mam.remaining_capacity) / lu_ssc.capacity_unit;
-		put_unaligned_be32(0xfffffffe, &pg->partition0remaining);
-		put_unaligned_be32(0xfffffffe, &pg->partition1remaining);
+/*
+ * Capacity of 'partition' in the units this drive reports capacities in.
+ * Zero for a partition which does not exist on the loaded medium.
+ */
+static uint32_t partition_capacity_units(int partition) {
+	uint64_t cap = medium_partition_capacity(lu_ssc.pm->lu, partition);
 
-		cap = get_unaligned_be64(&mam.max_capacity) / lu_ssc.capacity_unit;
-		put_unaligned_be32(0xfffffffe, &pg->partition0maximum);
-		put_unaligned_be32(0xfffffffe, &pg->partition1maximum);
+	return (uint32_t)(cap / lu_ssc.capacity_unit);
+}
+
+/*
+ * How much of 'partition' is still free, in the same units. Subtracting what
+ * has been written to that partition, not to the medium as a whole.
+ */
+static uint32_t partition_remaining_units(int partition) {
+	uint64_t cap  = medium_partition_capacity(lu_ssc.pm->lu, partition);
+	uint64_t used = partition_data_offset(partition);
+
+	if (used >= cap)
+		return 0;
+
+	return (uint32_t)((cap - used) / lu_ssc.capacity_unit);
+}
+
+void update_TapeCapacity(struct TapeCapacity_pg *pg) {
+	if (get_tape_load_status() == TAPE_LOADED) {
+		put_unaligned_be32(partition_remaining_units(0), &pg->partition0remaining);
+		put_unaligned_be32(partition_remaining_units(1), &pg->partition1remaining);
+
+		put_unaligned_be32(partition_capacity_units(0), &pg->partition0maximum);
+		put_unaligned_be32(partition_capacity_units(1), &pg->partition1maximum);
 	} else {
 		pg->partition0remaining = 0;
 		pg->partition0maximum	= 0;

--- a/usr/mhvtl_log.c
+++ b/usr/mhvtl_log.c
@@ -282,8 +282,8 @@ static void init_log_volume_statistics(void *log_ptr) {
 		   LOG_PARAM(0x0013, 0x03, LastLoadReadCompressionRatio)	  = 0x00,
 		   LOG_PARAM(0x0014, 0x03, MediumMountTime)					  = {0},
 		   LOG_PARAM(0x0015, 0x03, MediumReadyTime)					  = {0},
-		   LOG_PARAM(0x0016, 0x03, TotalNativeCapacity)				  = 0xfffffffe,
-		   LOG_PARAM(0x0017, 0x03, TotalUsedNativeCapacity)			  = 0xfffffffe,
+		   LOG_PARAM(0x0016, 0x03, TotalNativeCapacity)				  = htobe32(0xfffffffe),
+		   LOG_PARAM(0x0017, 0x03, TotalUsedNativeCapacity)			  = htobe32(0xfffffffe),
 		   LOG_PARAM(0x0018, 0x03, AppDesignCapacity)				  = 0x00,
 		   LOG_PARAM(0x0019, 0x03, VolumeLifetimeRemaining)			  = 0x00,
 		   LOG_PARAM(0x0040, 0x01, VolumeSerialNumber)				  = {0},
@@ -381,12 +381,16 @@ static struct DeviceStatus_pg *lookup_device_status_pg(void) {
 
 static void init_log_tape_capacity(void *log_ptr) {
 	struct TapeCapacity_pg *pg = log_ptr;
+	/* Capacities go on the wire big endian, so the placeholder these start out
+	 * with has to be stored that way too - it was being assigned in host order.
+	 * update_TapeCapacity() replaces them on every LOG SENSE.
+	 */
 	*pg						   = (struct TapeCapacity_pg){
 		   LOG_PG_HEADER(TAPE_CAPACITY),
-		   LOG_PARAM(0x0001, 0xc0, partition0remaining) = 0xfffffffe,
-		   LOG_PARAM(0x0002, 0xc0, partition1remaining) = 0xfffffffe,
-		   LOG_PARAM(0x0003, 0xc0, partition0maximum)	= 0xfffffffe,
-		   LOG_PARAM(0x0004, 0xc0, partition1maximum)	= 0xfffffffe,
+		   LOG_PARAM(0x0001, 0xc0, partition0remaining) = htobe32(0xfffffffe),
+		   LOG_PARAM(0x0002, 0xc0, partition1remaining) = htobe32(0xfffffffe),
+		   LOG_PARAM(0x0003, 0xc0, partition0maximum)	= htobe32(0xfffffffe),
+		   LOG_PARAM(0x0004, 0xc0, partition1maximum)	= htobe32(0xfffffffe),
 	   };
 }
 int add_log_tape_capacity(struct lu_phy_attr *lu) {
@@ -514,6 +518,23 @@ void update_VolumeStatistics(struct VolumeStatistics_pg *pg, struct priv_lu_ssc 
 		struct partition_record_size6 *p_header =
 			((struct partition_record_size6 *)(header + sizeof(struct pc_header))) + i;
 		put_unaligned_be48(0, &p_header->data);
+	}
+
+	/* The capacity of the volume as a whole, and how much of it is in use, in
+	 * the same units as the per-partition figures below. Both were left at a
+	 * placeholder, and one which had been assigned in host byte order at that.
+	 */
+	if (get_tape_load_status() == TAPE_LOADED) {
+		uint64_t total = 0;
+		uint64_t used  = 0;
+
+		for (i = 0; i < mam.num_partitions; ++i) {
+			total += medium_partition_capacity(lu_priv->pm->lu, i);
+			used += partition_data_offset(i);
+		}
+
+		put_unaligned_be32(total / lu_priv->capacity_unit, &pg->TotalNativeCapacity);
+		put_unaligned_be32(used / lu_priv->capacity_unit, &pg->TotalUsedNativeCapacity);
 	}
 
 	/* h_ApproxNativeCapacityPartition */

--- a/usr/mode.c
+++ b/usr/mode.c
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <inttypes.h>
 #include <errno.h>
 #include "mhvtl_scsi.h"
@@ -721,7 +722,51 @@ void set_medium_partition(struct scsi_cmd *cmd, uint8_t *p) {
  * down if they do not fit, and never take more than half of a medium which also
  * has a partition asking for the remainder.
  */
+/*
+ * Size of 'partition' in bytes as recorded on the medium, or zero if this
+ * cartridge carries no geometry - it predates the geometry being written, or
+ * has never been partitioned.
+ */
+static uint64_t recorded_partition_capacity(int partition) {
+	if ((partition < 0) || (partition >= MAX_PARTITIONS))
+		return 0;
+
+	return get_unaligned_be64(&mam.partition_capacity[partition]);
+}
+
+/*
+ * Work out the partition sizes the initiator has asked for and record them on
+ * the medium. Called when the medium is formatted, which is the only point at
+ * which the geometry changes.
+ */
+void set_medium_partition_capacity(struct lu_phy_attr *lu) {
+	int num = mam.num_partitions ? mam.num_partitions : 1;
+	int k;
+
+	memset(mam.partition_capacity, 0, sizeof(mam.partition_capacity));
+
+	for (k = 0; k < num; k++)
+		put_unaligned_be64(medium_partition_capacity_from_mode_page(lu, k),
+						   &mam.partition_capacity[k]);
+
+	for (k = 0; k < num; k++)
+		MHVTL_DBG(2, "Partition %d formatted to %" PRIu64 " bytes", k,
+				  get_unaligned_be64(&mam.partition_capacity[k]));
+}
+
 uint64_t medium_partition_capacity(struct lu_phy_attr *lu, int partition) {
+	uint64_t recorded = recorded_partition_capacity(partition);
+
+	/* What the medium says it was formatted to wins: the mode page belongs to
+	 * the drive and says nothing about the cartridge currently loaded.
+	 */
+	if (recorded)
+		return recorded;
+
+	return medium_partition_capacity_from_mode_page(lu, partition);
+}
+
+uint64_t medium_partition_capacity_from_mode_page(struct lu_phy_attr *lu, int partition) {
 	struct mode *mp;
 	uint64_t	 medium = get_unaligned_be64(&mam.max_capacity);
 	uint64_t	 size[MAX_PARTITIONS]	   = {0};

--- a/usr/mode.c
+++ b/usr/mode.c
@@ -698,10 +698,82 @@ void set_medium_partition(struct scsi_cmd *cmd, uint8_t *p) {
 	mp->pcodePointer[5] = p[5]; /* MEDIUM FORMAT RECOGNITION */
 	mp->pcodePointer[6] = p[6]; /* PARTITIONING TYPE | PARTITION UNITS */
 
-	/* PARTITION SIZES */
+	/* PARTITION SIZES - two bytes each, not one */
 	for (int k = 0; k < mam.num_partitions; k++) {
-		put_unaligned_be16(p[8 + 2 * k], &mp->pcodePointer[8 + 2 * k]);
+		put_unaligned_be16(get_unaligned_be16(&p[8 + (2 * k)]),
+						   &mp->pcodePointer[8 + (2 * k)]);
 	}
+}
+
+/*
+ * Size of 'partition' in bytes, according to the medium partition mode page.
+ *
+ * The page carries one size descriptor per partition, in units of 10^n bytes
+ * where n is the PARTITION UNITS field. A descriptor of 0xffff means "whatever
+ * is left of the medium" and is how an initiator asks for a partition which
+ * fills the tape: LTFS asks for a one gigabyte index partition and gives the
+ * remainder to the data partition.
+ *
+ * What the initiator asks for is capped so the partitions always add up to the
+ * medium rather than each believing it has the whole tape. Since the request is
+ * made without knowing the size of the cartridge - LTFS asks for its index
+ * partition in gigabytes whatever the medium - fixed size partitions are scaled
+ * down if they do not fit, and never take more than half of a medium which also
+ * has a partition asking for the remainder.
+ */
+uint64_t medium_partition_capacity(struct lu_phy_attr *lu, int partition) {
+	struct mode *mp;
+	uint64_t	 medium = get_unaligned_be64(&mam.max_capacity);
+	uint64_t	 size[MAX_PARTITIONS]	   = {0};
+	int			 remainder[MAX_PARTITIONS] = {0};
+	uint64_t	 unit					   = 1;
+	uint64_t	 fixed					   = 0;
+	uint64_t	 budget;
+	int			 num			 = mam.num_partitions ? mam.num_partitions : 1;
+	int			 remainder_count = 0;
+	int			 units, k;
+
+	if ((partition < 0) || (partition >= num))
+		return 0;
+
+	if (num == 1)
+		return medium;
+
+	mp = lookup_mode_pg(&lu->mode_pg, MODE_MEDIUM_PARTITION, 0);
+	if (!mp) /* Nothing to go on - share the medium out evenly */
+		return medium / num;
+
+	units = mp->pcodePointer[6] & 0x0f;
+	while (units--)
+		unit *= 10;
+
+	for (k = 0; k < num; k++) {
+		uint16_t descriptor = get_unaligned_be16(&mp->pcodePointer[8 + (2 * k)]);
+
+		if (descriptor == 0xffff) {
+			remainder[k] = 1;
+			remainder_count++;
+		} else {
+			size[k] = (uint64_t)descriptor * unit;
+			fixed += size[k];
+		}
+	}
+
+	budget = remainder_count ? medium / 2 : medium;
+	if (fixed > budget) {
+		/* Scaled in floating point - the product of two capacities does not
+		 * fit in 64 bits, and a byte of rounding either way is immaterial.
+		 */
+		for (k = 0; k < num; k++)
+			if (!remainder[k])
+				size[k] = (uint64_t)((double)size[k] * budget / fixed);
+		fixed = budget;
+	}
+
+	if (remainder[partition])
+		return (medium - fixed) / remainder_count;
+
+	return size[partition];
 }
 
 int add_mode_power_condition(struct lu_phy_attr *lu) {

--- a/usr/mode.c
+++ b/usr/mode.c
@@ -754,6 +754,67 @@ void set_medium_partition_capacity(struct lu_phy_attr *lu) {
 				  get_unaligned_be64(&mam.partition_capacity[k]));
 }
 
+/*
+ * Bring the medium partition mode page into line with the loaded volume.
+ *
+ * SSC has the device server do this when the medium goes from demounted to
+ * mounted: the fields describing the current state of the partitions are set
+ * from the medium, so that an initiator reading the page back learns how the
+ * cartridge in the drive is actually laid out rather than how some earlier
+ * MODE SELECT asked for a cartridge to be formatted.
+ *
+ * The units a volume was partitioned with are explicitly not retained, so the
+ * finest unit which still lets every partition fit a sixteen bit descriptor is
+ * used for reporting.
+ */
+void update_medium_partition_page(struct lu_phy_attr *lu) {
+	struct mode *mp		 = lookup_mode_pg(&lu->mode_pg, MODE_MEDIUM_PARTITION, 0);
+	uint64_t	 largest = 0;
+	uint64_t	 unit	 = 1;
+	int			 num	 = mam.num_partitions ? mam.num_partitions : 1;
+	int			 units, k;
+
+	if (!mp)
+		return;
+
+	if (num > MAX_PARTITIONS)
+		num = MAX_PARTITIONS;
+
+	for (k = 0; k < num; k++) {
+		uint64_t sz = medium_partition_capacity(lu, k);
+
+		if (sz > largest)
+			largest = sz;
+	}
+
+	for (units = 0; units < 15; units++, unit *= 10)
+		if (largest / unit <= 0xfffe)
+			break;
+
+	/* Maximum additional partitions and additional partitions defined both
+	 * describe the loaded volume, as N-1.
+	 */
+	mp->pcodePointer[2] = mam.max_partitions ? mam.max_partitions - 1 : 0;
+	mp->pcodePointer[3] = num - 1;
+
+	/* Partitioning type stays in the top nibble, units go in the bottom */
+	mp->pcodePointer[6] = (mp->pcodePointer[6] & 0xf0) | (units & 0x0f);
+
+	for (k = 0; k < MAX_PARTITIONS; k++) {
+		uint64_t sz = (k < num) ? medium_partition_capacity(lu, k) : 0;
+		uint16_t descriptor = sz / unit;
+
+		/* The descriptor for a partition which exists has to be non-zero */
+		if (!descriptor && sz)
+			descriptor = 1;
+
+		put_unaligned_be16(descriptor, &mp->pcodePointer[8 + (2 * k)]);
+	}
+
+	MHVTL_DBG(2, "Medium partition page: %d partition(s), sizes in 10^%d bytes",
+			  num, units);
+}
+
 uint64_t medium_partition_capacity(struct lu_phy_attr *lu, int partition) {
 	uint64_t recorded = recorded_partition_capacity(partition);
 

--- a/usr/ssc.c
+++ b/usr/ssc.c
@@ -644,6 +644,13 @@ uint8_t ssc_format_medium(struct scsi_cmd *cmd) {
 		return SAM_STAT_CHECK_CONDITION;
 	}
 
+	/* Formatting is the only thing which changes the geometry, so record it on
+	 * the medium now: the partition layout has to be readable by whichever
+	 * drive loads this cartridge next, exactly as it would be on real tape.
+	 */
+	set_medium_partition_capacity(lu);
+	rewriteMAM(sam_stat);
+
 	return SAM_STAT_GOOD;
 }
 

--- a/usr/ssc.c
+++ b/usr/ssc.c
@@ -1900,7 +1900,7 @@ uint8_t ssc_write_filemarks(struct scsi_cmd *cmd) {
 	write_filemarks(count, sam_stat);
 	if (count) {
 		if (current_tape_offset() >=
-			get_unaligned_be64(&mam.max_capacity)) {
+			medium_partition_capacity(lu, c_pos->partition_id)) {
 			mam.remaining_capacity = 0L;
 			MHVTL_DBG(2, "Setting EOM flag");
 			sam_no_sense(SD_EOM, NO_ADDITIONAL_SENSE, sam_stat);

--- a/usr/ssc.c
+++ b/usr/ssc.c
@@ -1990,6 +1990,9 @@ uint8_t ssc_log_sense(struct scsi_cmd *cmd) {
 		break;
 
 	case TAPE_CAPACITY:
+		update_TapeCapacity((struct TapeCapacity_pg *)buf);
+		break;
+
 	case DATA_COMPRESSION:
 		break;
 

--- a/usr/ssc.c
+++ b/usr/ssc.c
@@ -1903,7 +1903,7 @@ uint8_t ssc_write_filemarks(struct scsi_cmd *cmd) {
 			medium_partition_capacity(lu, c_pos->partition_id)) {
 			mam.remaining_capacity = 0L;
 			MHVTL_DBG(2, "Setting EOM flag");
-			sam_no_sense(SD_EOM, NO_ADDITIONAL_SENSE, sam_stat);
+			sam_no_sense(SD_EOM, E_EOM, sam_stat);
 		}
 	}
 

--- a/usr/vtlcart.c
+++ b/usr/vtlcart.c
@@ -849,13 +849,20 @@ static void close_partition(uint8_t partition_number) {
 }
 
 int change_partition(uint8_t partition_number) {
-	uint8_t *sam_stat = SAM_STAT_GOOD;
-	int		 rc		  = 0;
+	/* Somewhere for read_header() to report a failure. This used to be a
+	 * pointer initialised to SAM_STAT_GOOD, which is zero - so the moment
+	 * read_header() failed, on a medium whose header could not be read, it
+	 * wrote through a null pointer.
+	 */
+	uint8_t sam_stat = SAM_STAT_GOOD;
+	int		rc		 = 0;
 
 	close_partition(c_pos->partition_id);
 	c_pos->partition_id = partition_number;
 	rc					= open_partition(partition_number);
-	read_header(0, sam_stat);
+	if (read_header(0, &sam_stat))
+		MHVTL_ERR("Could not read the first header of partition %d",
+				  partition_number);
 	return rc;
 }
 

--- a/usr/vtlcart.c
+++ b/usr/vtlcart.c
@@ -1621,6 +1621,20 @@ uint64_t current_tape_offset(void) {
 	return 0;
 }
 
+/*
+ * Bytes written in 'partition' - the data offset of its end of data.
+ *
+ * Unlike current_tape_offset() this works for any partition, not just the one
+ * the drive is positioned in, so capacity reporting can describe the whole
+ * medium.
+ */
+uint64_t partition_data_offset(int partition) {
+	if ((partition < 0) || (partition >= MAX_PARTITIONS))
+		return 0;
+
+	return eod_data_offset[partition];
+}
+
 uint64_t current_tape_block(void) {
 	if (datafile[c_pos->partition_id] != -1)
 		return (uint64_t)c_pos->blk_number;

--- a/usr/vtllib.c
+++ b/usr/vtllib.c
@@ -1922,7 +1922,7 @@ unsigned int set_media_params(struct MAM *mamp, char *density) {
 		memcpy(&mamp->media_info.density_name, "U-732  ", 6);
 		memcpy(&mamp->AssigningOrganization_1, "LTO-CVE", 7);
 		put_unaligned_be32(19107, &mamp->media_info.bits_per_mm);
-		mamp->max_partitions = 2;
+		mamp->max_partitions = 4;
 		mamp->num_partitions = 2;
 	} else if (!(strncmp(density, "LTO8", 4))) {
 		mamp->MediumDensityCode = medium_density_code_lto8;
@@ -1933,7 +1933,7 @@ unsigned int set_media_params(struct MAM *mamp, char *density) {
 		memcpy(&mamp->media_info.density_name, "U-832  ", 6);
 		memcpy(&mamp->AssigningOrganization_1, "LTO-CVE", 7);
 		put_unaligned_be32(19107, &mamp->media_info.bits_per_mm);
-		mamp->max_partitions = 2;
+		mamp->max_partitions = 4;
 		mamp->num_partitions = 2;
 	} else if (!(strncmp(density, "LTO9", 4))) {
 		mamp->MediumDensityCode = medium_density_code_lto9;
@@ -1944,7 +1944,7 @@ unsigned int set_media_params(struct MAM *mamp, char *density) {
 		memcpy(&mamp->media_info.density_name, "U-932  ", 6);
 		memcpy(&mamp->AssigningOrganization_1, "LTO-CVE", 7);
 		put_unaligned_be32(19107, &mamp->media_info.bits_per_mm);
-		mamp->max_partitions = 2;
+		mamp->max_partitions = 4;
 		mamp->num_partitions = 2;
 	} else if (!(strncmp(density, "AIT1", 4))) {
 		/* Vaules for AIT taken from "Product Manual SDX-900V v1.0" */

--- a/usr/vtllib.c
+++ b/usr/vtllib.c
@@ -1724,6 +1724,26 @@ finished:
  * holds. Cartridge data files are sparse, so a large capacity here costs
  * nothing until it is written to.
  */
+/*
+ * How many partitions a cartridge of this media type can hold.
+ *
+ * LTO-5 and LTO-6 hold two partitions, LTO-7 raised that to four and LTO-8 and
+ * LTO-9 kept it. Everything else is described as a single partition.
+ */
+uint8_t media_max_partitions(uint8_t media_type) {
+	switch (media_type) {
+	case Media_LTO5:
+	case Media_LTO6:
+		return 2;
+	case Media_LTO7:
+	case Media_LTO8:
+	case Media_LTO9:
+		return 4;
+	default:
+		return 1;
+	}
+}
+
 uint64_t media_native_capacity(uint8_t media_type) {
 	const uint64_t GB = 1000000000ULL; /* Capacities are quoted in SI units */
 
@@ -1900,7 +1920,6 @@ unsigned int set_media_params(struct MAM *mamp, char *density) {
 		memcpy(&mamp->media_info.density_name, "U-516  ", 6);
 		memcpy(&mamp->AssigningOrganization_1, "LTO-CVE", 7);
 		put_unaligned_be32(15142, &mamp->media_info.bits_per_mm);
-		mamp->max_partitions = 2;
 		mamp->num_partitions = 2;
 	} else if (!(strncmp(density, "LTO6", 4))) {
 		mamp->MediumDensityCode = medium_density_code_lto6;
@@ -1911,7 +1930,6 @@ unsigned int set_media_params(struct MAM *mamp, char *density) {
 		memcpy(&mamp->media_info.density_name, "U-616  ", 6);
 		memcpy(&mamp->AssigningOrganization_1, "LTO-CVE", 7);
 		put_unaligned_be32(18441, &mamp->media_info.bits_per_mm);
-		mamp->max_partitions = 2;
 		mamp->num_partitions = 2;
 	} else if (!(strncmp(density, "LTO7", 4))) {
 		mamp->MediumDensityCode = medium_density_code_lto7;
@@ -1922,7 +1940,6 @@ unsigned int set_media_params(struct MAM *mamp, char *density) {
 		memcpy(&mamp->media_info.density_name, "U-732  ", 6);
 		memcpy(&mamp->AssigningOrganization_1, "LTO-CVE", 7);
 		put_unaligned_be32(19107, &mamp->media_info.bits_per_mm);
-		mamp->max_partitions = 4;
 		mamp->num_partitions = 2;
 	} else if (!(strncmp(density, "LTO8", 4))) {
 		mamp->MediumDensityCode = medium_density_code_lto8;
@@ -1933,7 +1950,6 @@ unsigned int set_media_params(struct MAM *mamp, char *density) {
 		memcpy(&mamp->media_info.density_name, "U-832  ", 6);
 		memcpy(&mamp->AssigningOrganization_1, "LTO-CVE", 7);
 		put_unaligned_be32(19107, &mamp->media_info.bits_per_mm);
-		mamp->max_partitions = 4;
 		mamp->num_partitions = 2;
 	} else if (!(strncmp(density, "LTO9", 4))) {
 		mamp->MediumDensityCode = medium_density_code_lto9;
@@ -1944,7 +1960,6 @@ unsigned int set_media_params(struct MAM *mamp, char *density) {
 		memcpy(&mamp->media_info.density_name, "U-932  ", 6);
 		memcpy(&mamp->AssigningOrganization_1, "LTO-CVE", 7);
 		put_unaligned_be32(19107, &mamp->media_info.bits_per_mm);
-		mamp->max_partitions = 4;
 		mamp->num_partitions = 2;
 	} else if (!(strncmp(density, "AIT1", 4))) {
 		/* Vaules for AIT taken from "Product Manual SDX-900V v1.0" */
@@ -2167,6 +2182,7 @@ unsigned int set_media_params(struct MAM *mamp, char *density) {
 		return 1;
 	}
 	mamp->FormattedDensityCode = mamp->MediumDensityCode;
+	mamp->max_partitions	   = media_max_partitions(mamp->MediaType);
 
 	/* Cartridge memory size, so that the MAM capacity attributes describe the
 	 * memory in the cartridge rather than the length of the tape.

--- a/usr/vtllib.c
+++ b/usr/vtllib.c
@@ -1707,6 +1707,134 @@ finished:
 	fclose(conf);
 }
 
+/*
+ * Native (uncompressed) capacity of a media type, in bytes.
+ *
+ * Used when media is created without an explicit capacity, so that a cartridge
+ * claiming to be a given generation reports the size that generation actually
+ * holds. Cartridge data files are sparse, so a large capacity here costs
+ * nothing until it is written to.
+ */
+uint64_t media_native_capacity(uint8_t media_type) {
+	const uint64_t GB = 1000000000ULL; /* Capacities are quoted in SI units */
+
+	switch (media_type) {
+	case Media_LTO1:
+		return 100 * GB;
+	case Media_LTO2:
+		return 200 * GB;
+	case Media_LTO3:
+		return 400 * GB;
+	case Media_LTO4:
+		return 800 * GB;
+	case Media_LTO5:
+		return 1500 * GB;
+	case Media_LTO6:
+		return 2500 * GB;
+	case Media_LTO7:
+		return 6000 * GB;
+	case Media_LTO8:
+		return 12000 * GB;
+	case Media_LTO9:
+		return 18000 * GB;
+	/* set_media_params() uses these media types to stand for the 3592 format
+	 * generations rather than for the WORM cartridges their names suggest:
+	 * J1A -> JA, E05 -> JB, E06 -> JX, E07 -> JK. Each gets the headline
+	 * native capacity of that generation.
+	 */
+	case Media_3592_JA:
+		return 300 * GB;
+	case Media_3592_JB:
+		return 700 * GB;
+	case Media_3592_JX:
+		return 1000 * GB;
+	case Media_3592_JK:
+		return 4000 * GB;
+	case Media_T10KA:
+		return 500 * GB;
+	case Media_T10KB:
+		return 1000 * GB;
+	case Media_T10KC:
+		return 5000 * GB;
+	case Media_AIT1:
+		return 35 * GB;
+	case Media_AIT2:
+		return 50 * GB;
+	case Media_AIT3:
+		return 100 * GB;
+	case Media_AIT4:
+		return 200 * GB;
+	case Media_DLT3:
+		return 10 * GB;
+	case Media_DLT4:
+		return 20 * GB;
+	case Media_SDLT:
+		return 100 * GB;
+	case Media_SDLT220:
+		return 110 * GB;
+	case Media_SDLT320:
+		return 160 * GB;
+	case Media_SDLT600:
+		return 300 * GB;
+	case Media_DDS1:
+		return 2 * GB;
+	case Media_DDS2:
+		return 4 * GB;
+	case Media_DDS3:
+		return 12 * GB;
+	case Media_DDS4:
+		return 20 * GB;
+	default:
+		/* Cleaning cartridges and anything unrecognised. Small, but not zero,
+		 * since zero means "use the native capacity" to the caller.
+		 */
+		return GB;
+	}
+}
+
+/*
+ * Size of the medium auxiliary memory in a cartridge of this media type, in
+ * bytes. LTO cartridge memory grew from 4KB to 8KB with LTO-5 and to 16KB with
+ * LTO-9; other formats are given the same 8KB as a reasonable default.
+ */
+uint64_t media_mam_capacity(uint8_t media_type) {
+	switch (media_type) {
+	case Media_LTO1:
+	case Media_LTO2:
+	case Media_LTO3:
+	case Media_LTO4:
+		return 4096;
+	case Media_LTO9:
+		return 16384;
+	default:
+		return 8192;
+	}
+}
+
+/*
+ * Recalculate the MAM space remaining attribute: the cartridge memory less what
+ * the attributes held in it occupy, each costing its value plus the five byte
+ * identifier, format and length header.
+ */
+void mam_space_remaining(struct MAM *mamp) {
+	uint64_t capacity = get_unaligned_be64(&mamp->MAMCapacity);
+	uint64_t used	  = 0;
+	int		 i;
+
+	if (!capacity) {
+		/* Media created before the cartridge memory size was recorded */
+		capacity = media_mam_capacity(mamp->MediaType);
+		put_unaligned_be64(capacity, &mamp->MAMCapacity);
+	}
+
+	for (i = 0; i < MAM_ATTRIBUTE_END; i++)
+		if (mamp->attributes[i].length)
+			used += mamp->attributes[i].length + 5;
+
+	put_unaligned_be64((used < capacity) ? capacity - used : 0,
+					   &mamp->MAMSpaceRemaining);
+}
+
 unsigned int set_media_params(struct MAM *mamp, char *density) {
 	/* Invent some defaults */
 	mamp->MediaType = Media_undefined;
@@ -2030,6 +2158,20 @@ unsigned int set_media_params(struct MAM *mamp, char *density) {
 		return 1;
 	}
 	mamp->FormattedDensityCode = mamp->MediumDensityCode;
+
+	/* Cartridge memory size, so that the MAM capacity attributes describe the
+	 * memory in the cartridge rather than the length of the tape.
+	 */
+	put_unaligned_be64(media_mam_capacity(mamp->MediaType), &mamp->MAMCapacity);
+
+	/* A capacity of zero means "whatever this media type natively holds" */
+	if (!get_unaligned_be64(&mamp->max_capacity)) {
+		uint64_t native = media_native_capacity(mamp->MediaType);
+
+		put_unaligned_be64(native, &mamp->max_capacity);
+		put_unaligned_be64(native, &mamp->remaining_capacity);
+	}
+
 	return 0;
 }
 

--- a/usr/vtllib.c
+++ b/usr/vtllib.c
@@ -145,7 +145,10 @@ void init_mam(struct MAM *mamp) {
 	/* 0x0c00 - 0x0fff - Device - Vendor Specific */
 	/* 0x1000 - 0x13ff - Medium - Vendor Specific */
 	/* 0x1400 - 0x17ff -  Host  - Vendor Specific */
-	INIT_MAM_ATTR(0x1623, 1, 1, 0, mamp->VolumeLock, MAM_VOLUME_LOCK);
+	/* Host vendor specific, and written by the application - LTFS keeps the
+	 * volume lock state here - so not read only.
+	 */
+	INIT_MAM_ATTR(0x1623, 1, 0, 0, mamp->VolumeLock, MAM_VOLUME_LOCK);
 
 	/* 0x1800 : end of implemented attributes */
 	mamp->attributes[MAM_ATTRIBUTE_END] = (struct MAM_attr){0x1800, 0, 1, 0, NULL};

--- a/usr/vtllib.c
+++ b/usr/vtllib.c
@@ -167,6 +167,12 @@ void init_mam(struct MAM *mamp) {
 	INIT_VTL_ATTR(0x0b, MAM_COHERENCY_LEN, mamp->VolumeCoherencyInformation[2], MAM_MHVTL_VOLUME_COHERENCY_P2);
 	INIT_VTL_ATTR(0x0c, MAM_COHERENCY_LEN, mamp->VolumeCoherencyInformation[3], MAM_MHVTL_VOLUME_COHERENCY_P3);
 
+	/* Partition geometry, so that it survives the drive it was formatted in */
+	INIT_VTL_ATTR(0x0d, 8, mamp->partition_capacity[0], MAM_MHVTL_PARTITION_CAPACITY_P0);
+	INIT_VTL_ATTR(0x0e, 8, mamp->partition_capacity[1], MAM_MHVTL_PARTITION_CAPACITY_P1);
+	INIT_VTL_ATTR(0x0f, 8, mamp->partition_capacity[2], MAM_MHVTL_PARTITION_CAPACITY_P2);
+	INIT_VTL_ATTR(0x10, 8, mamp->partition_capacity[3], MAM_MHVTL_PARTITION_CAPACITY_P3);
+
 	INIT_VTL_ATTR(0x06, 4, mamp->media_info.bits_per_mm, MAM_MHVTL_MEDIAINFO_BITS_PER_MM);
 	INIT_VTL_ATTR(0x07, 2, mamp->media_info.tracks, MAM_MHVTL_MEDIAINFO_TRACKS);
 	INIT_VTL_ATTR(0x08, 8, mamp->media_info.density_name, MAM_MHVTL_MEDIAINFO_DENSITY_NAME);


### PR DESCRIPTION
Capacity, partitioning and end of medium were reported with placeholder values,
in the wrong units, and without regard to partitioning. On a partitioned
cartridge every partition believed it had the whole medium, so end of medium was
unreachable and nothing which depended on it had ever run. Fixing the reporting
made it reachable, and each fix from there uncovered the next one:

- Real capacities made end of medium reachable, which exposed
- a null pointer dereference in `change_partition()` that killed the drive
  daemon and left cartridges unloadable, and once that was fixed a volume
  survived long enough to show that
- early warning was reported as ASC/ASCQ 00/00, so no initiator could act on it
  and LTFS wrote on until the medium refused it, with no room left for the index
  which closes the volume. With end of medium behaving,
- partition sizes turned out not to survive a daemon restart, because the
  geometry lived in the drive rather than on the medium, and finally
- the tape capacity log page turned out never to be refreshed at all: its
  updater was not called from LOG SENSE.

## What each commit fixes

| commit | defect |
| --- | --- |
| `fix(capacity)` | The tape capacity log page (0x31) and the volume statistics page (0x17) returned the constant `0xfffffffe` for every capacity field, page 0x31 carrying a `/* fixme */` on a variable which computed the right value and discarded it. MAM attributes 0x0000/0x0001 held bytes where SSC specifies megabytes. Partition sizes arrived mangled because `set_medium_partition()` read the 16-bit size descriptors one byte at a time. Capacity is now per partition, in the right units, and enforced by end of medium, early warning and WRITE FILEMARKS. |
| `fix(vtlcart)` | `change_partition()` declared `uint8_t *sam_stat = SAM_STAT_GOOD`, a pointer initialised to zero. `read_header()` writes through it on failure, so loading a medium whose first header could not be read killed the daemon with SIGSEGV, taking the command in flight with it. |
| `fix(ssc)` | Early warning was reported with the EOM bit and ASC/ASCQ 00/00, which means "no additional sense information". It is 00/02, END-OF-PARTITION/MEDIUM DETECTED, the code `E_EOM` already holds and which the programmable early warning path beside it already used correctly. |
| `fix(mam)` (volume lock) | Attribute 0x1623 was flagged read only although it is in the host vendor specific range and LTFS writes the volume lock state to it. |
| `fix(mam)` (geometry) | Partitioning belongs to the cartridge. It was kept only in the medium partition mode page, which is drive state, so a daemon restart replaced a 953MB/1094MB layout with an even split - moving where each partition ended, not just what was reported. |
| `fix(mode)` | SSC has the drive set the partition fields of mode page 0x11 from the medium when a volume is mounted. mhvtl left the page at its compiled-in defaults, describing four partitions of 2GB on a two partition cartridge of 953MB and 1094MB. |
| `fix(media)` (four partitions) | LTO-7 raised the partition limit from two to four; every LTO media type from 5 onwards was described as holding two. |
| `fix(media)` (derive) | The partition count was recorded per cartridge, so existing media kept whatever count the mhvtl which created it believed in. It now follows from the media type, in one place rather than repeated per density. |
| `fix(log)` | `update_TapeCapacity()` was never called: LOG SENSE handled page 0x31 in the group which falls through with a bare break, so the page returned its initialiser for the life of the daemon. The placeholders in it were also assigned in host byte order, putting `0xfeffffff` on the wire where `0xfffffffe` was meant, and the total native capacity and total used native capacity parameters of page 0x17 had no code filling them in at all. |

## Measured effect

Against ltfs 2.4.8.4 with an emulated IBM ULT3580-TD8, on a 2GiB cartridge
partitioned by `mkltfs`. Log pages and attributes read back with `sg_logs`,
`sg_read_attr` and `sg_modes` rather than with anything from this tree:

| | before | after |
| --- | --- | --- |
| volume size seen by LTFS | 2.0P | 589M |
| `tapeinfo` partition capacity | -16777217 KB | correct |
| MAM maximum capacity (0x0001) | 524288000 "MB" on both partitions | 953MB and 1094MB, summing to the cartridge |
| MAM space remaining (0x0004) | 70501888162088 | 7090 of 8192 bytes |
| log page 0x31, remaining and maximum | 4278190079 MiB on both partitions | 953 and 1094 MiB |
| log page 0x17, per partition | 4278190079 MB | 953 and 1094 MB |
| log page 0x17, volume totals | 4278190079 MB | 2048 MB total, 0 MB used |
| mode page 0x11 | four partitions of 2GB | two partitions of 953MB and 1094MB |
| early warning | not reported in a form anything could read | `LTFS30222W Received low space warning` |
| unmounting a full volume | `LTFS11033E Cannot unmount: failed to write an index` | index written, `LTFS11034I Volume unmounted successfully` |
| data written before end of medium | lost | intact and verified by checksum after unload and reload |
| geometry after a daemon restart | reset to an even split | read back off the medium |
| loading a cartridge with an unreadable header | daemon SIGSEGV | `02/3a/00` NOT READY |

Media created without an explicit capacity now report the native capacity of the
media type: 2.5TB for LTO-6, 12TB for LTO-8, 18TB for LTO-9, 4TB for 3592 E07,
5TB for T10000C. Cartridge files stay sparse, so a cartridge which reports 12TB
still occupies 16KB until written to.

Also checked: `tar` write and read back on an unpartitioned cartridge, filemark
and EOD behaviour, `mtx` inventory and load/unload, and that compressible data
still occupies only what it compresses to - the first attempt at filling a
partition used `/dev/zero` and never reached the end of the medium.

## Notes for review

- `mktape -s 0` previously meant an eight gigabyte cartridge and now means the
  native capacity of the media type. Flagged as `BREAKING CHANGE:` on the first
  commit. An explicit `-s` is unchanged.
- Which log page an initiator reads for capacity varies: LTFS uses the volume
  statistics page on LTO-6 and later drives and the tape capacity page on LTO-5,
  which is why page 0x31 never being refreshed went unnoticed. Both are fixed.
- `MAM_VERSION` is deliberately left at 4. Bumping it would send every existing
  cartridge through `try_update_mam()`, which only converts version 3 and
  rejects anything else as `E_MEDIUM_FMT_CORRUPT`. Instead `read_mam()` now
  clamps each stored value to the field it is read into and steps over any
  remainder, so media written by either version loads, and a bogus length in the
  file can no longer overrun the struct.
- Media carrying no recorded geometry - anything formatted before this - reads as
  zero and falls back to the previous behaviour.
- Partition sizes in mode page 0x11 are rounded to the reporting unit, 0.01% at
  these cartridge sizes and inherent to the 16-bit descriptors. The standard
  states the units used to partition a volume are not retained, so the finest
  unit which fits every partition is chosen when reporting.
- The four partition capability is advertised from the media type but only two
  partition media was exercised, since that is what LTFS asks for.
- `WRITE ATTRIBUTE` now rejects writes to read-only attributes instead of
  letting an initiator overwrite the drive's own counters, and its rollback on
  error was `memcpy(&mamp, &mam_backup, sizeof(mamp))`, copying eight bytes over
  a local pointer rather than restoring the MAM.

Behaviour for mode page 0x11 follows the IBM LTO SCSI Reference (GA32-0928),
6.5.12: "Fields in the Medium Partition mode page indicating the current state of
the partitions for the medium are changed by the device server to the current
medium state on a not ready to ready transition when the medium state changes
from demounted to mounted", and "ADDITIONAL PARTITIONS DEFINED: This field
specifies the number of additional partitions on the mounted volume".
