### PR TITLE
Makefile: fix the tar flags for the kernel tarball (-cfz -> -czf)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ endif
 tar: distclean
 	test -d ../$(PARENTDIR) || ln -s $(TOPDIR) ../$(PARENTDIR)
 	(cd kernel; tar --transform='s|.*/||' \
-		-cfz ../mhvtl_kernel.tgz * ../include/common/*)
+		-czf ../mhvtl_kernel.tgz * ../include/common/*)
 	(cd ..;  tar cvzf $(TAR_FILE) --exclude='.git*' \
 		 $(PARENTDIR)/man \
 		 $(PARENTDIR)/doc \


### PR DESCRIPTION
With `-cfz`, tar takes `z` as the archive name, so `make tar` writes an uncompressed `kernel/z` and fails before `mhvtl_kernel.tgz` exists. Verified on current master; with the fix `make tar` succeeds and produces `mhvtl_kernel.tgz` (14 entries).