### PR TITLE
fix(ssc): write the correct block on multi-block fixed writes

### DIFF
--- a/include/ssc.h
+++ b/include/ssc.h
@@ -285,7 +285,7 @@ struct read_position_information_extended {
 void ssc_personality_module_register(struct ssc_personality_template *pm);
 
 int readBlock(uint8_t *buf, uint32_t request_sz, int sili, int lbp, uint8_t *sam_stat);
-int writeBlock(struct scsi_cmd *cmd, uint32_t request_sz);
+int writeBlock(struct scsi_cmd *cmd, uint32_t request_sz, uint32_t src_offset);
 
 uint8_t ssc_a3_service_action(struct scsi_cmd *cmd);
 uint8_t ssc_a4_service_action(struct scsi_cmd *cmd);

--- a/usr/cmd/tape_util.c
+++ b/usr/cmd/tape_util.c
@@ -326,7 +326,7 @@ static int write_tape(char *source_file, uint32_t block_size, char *compression,
 				printf("zeroing out remaining block: %" PRIu32 "\n", (uint32_t)(block_size - count));
 				memset(b + count, 0, block_size - count); /* Zero out remaining block */
 			}
-			retval = writeBlock(&cmd, count);
+			retval = writeBlock(&cmd, count, 0);
 			if (retval < count) {
 				if (sense[2] == (VOLUME_OVERFLOW | SD_EOM) && sense[13] == E_EOM) {
 					printf("No space left on media, hit EOM while writing\n");

--- a/usr/mhvtl_io.c
+++ b/usr/mhvtl_io.c
@@ -360,18 +360,23 @@ int readBlock(uint8_t *buf, uint32_t request_sz, int sili, int lbp_method, uint8
 	case 1:
 		rc = BlockProtectRSCRC(bounce_buffer, rc, lbp_rscrc_be);
 		if (rc == 0) {
+			/* Nothing was appended, so there is no protection information to
+			 * hand back and rc-relative indexing below would run off the
+			 * front of the buffer.
+			 */
 			MHVTL_ERR("Failed to generate/append RSCRC: lbp_be: %d", lbp_rscrc_be);
+			sam_hardware_error(E_LOGICAL_BLOCK_GUARD_FAILED, sam_stat);
+			goto free_bounce_buf;
 		}
 		MHVTL_DBG(2, "READ block %d LBP RSCRC : 0x%02x 0x%02x 0x%02x 0x%02x", blk_number, bounce_buffer[rc - 4], bounce_buffer[rc - 3], bounce_buffer[rc - 2], bounce_buffer[rc - 1]);
 		break;
 	case 2:
-		MHVTL_DBG(2, "rc: %d, request_sz: %d bounce buffer before LBP: 0x%08x %08x", rc, request_sz, get_unaligned_be32(&bounce_buffer[rc - 4]), get_unaligned_be32(&bounce_buffer[rc]));
 		/* If we don't have a LBP CRC32C format, re-calculate now */
 		lbp_crc = (blk_flags & BLKHDR_FLG_CRC) ? pre_crc : mhvtl_crc32c(bounce_buffer, rc);
-		memcpy(&bounce_buffer[rc], &lbp_crc, 4);
+		/* Protection information is a big-endian field on the wire */
+		put_unaligned_be32(lbp_crc, &bounce_buffer[rc]);
 		MHVTL_DBG(2, "Logical Block Protection - CRC32C, rc: %d, request_sz: %d, lbp_size: %d, CRC32C: 0x%8x", rc, request_sz, lbp_sz, lbp_crc);
-		MHVTL_DBG(2, "rc: %d, request_sz: %d bounce buffer after LBP: 0x%08x %08x", rc, request_sz, get_unaligned_be32(&bounce_buffer[rc - 4]), get_unaligned_be32(&bounce_buffer[rc]));
-		MHVTL_DBG(2, "READ block %d LBP RSCRC : 0x%02x 0x%02x 0x%02x 0x%02x", blk_number, bounce_buffer[rc], bounce_buffer[rc + 1], bounce_buffer[rc + 2], bounce_buffer[rc + 3]);
+		MHVTL_DBG(2, "READ block %d LBP CRC32C : 0x%02x 0x%02x 0x%02x 0x%02x", blk_number, bounce_buffer[rc], bounce_buffer[rc + 1], bounce_buffer[rc + 2], bounce_buffer[rc + 3]);
 		rc += 4; /* Account for LBP checksum */
 		break;
 	case 3:
@@ -536,9 +541,9 @@ static void log_lbp_method(int lbp_method) {
  *
  * Zero on error with sense buffer already filled in
  */
-static int writeBlock_nocomp(struct scsi_cmd *cmd, uint32_t src_sz, uint8_t null_wr, int lbp_method) {
+static int writeBlock_nocomp(struct scsi_cmd *cmd, uint32_t src_sz, uint32_t src_offset, uint8_t null_wr, int lbp_method) {
 	uint8_t			   *sam_stat = &cmd->dbuf_p->sam_stat;
-	uint8_t			   *src_buf	 = (uint8_t *)cmd->dbuf_p->data;
+	uint8_t			   *src_buf	 = (uint8_t *)cmd->dbuf_p->data + src_offset;
 	struct priv_lu_ssc *lu_priv;
 	uint32_t			crc;
 	int					rc;
@@ -574,14 +579,14 @@ static int writeBlock_nocomp(struct scsi_cmd *cmd, uint32_t src_sz, uint8_t null
  *
  * Zero on error with sense buffer already filled in
  */
-static int writeBlock_lzo(struct scsi_cmd *cmd, uint32_t src_sz, uint8_t null_wr, int lbp_method) {
+static int writeBlock_lzo(struct scsi_cmd *cmd, uint32_t src_sz, uint32_t src_offset, uint8_t null_wr, int lbp_method) {
 	lzo_uint  dest_len;
 	lzo_uint  src_len = src_sz;
 	lzo_bytep dest_buf;
 	lzo_bytep wrkmem = NULL;
 	uint32_t  crc;
 
-	lzo_bytep src_buf = (lzo_bytep)cmd->dbuf_p->data;
+	lzo_bytep src_buf = (lzo_bytep)cmd->dbuf_p->data + src_offset;
 
 	uint8_t *sam_stat = &cmd->dbuf_p->sam_stat;
 
@@ -649,12 +654,12 @@ static int writeBlock_lzo(struct scsi_cmd *cmd, uint32_t src_sz, uint8_t null_wr
  *
  * Zero on error with sense buffer already filled in
  */
-static int writeBlock_zlib(struct scsi_cmd *cmd, uint32_t src_sz, uint8_t null_wr, int lbp_method) {
+static int writeBlock_zlib(struct scsi_cmd *cmd, uint32_t src_sz, uint32_t src_offset, uint8_t null_wr, int lbp_method) {
 	Bytef			   *dest_buf;
 	uLong				dest_len;
 	uLong				src_len	 = src_sz;
 	uint8_t			   *sam_stat = &cmd->dbuf_p->sam_stat;
-	uint8_t			   *src_buf	 = (uint8_t *)cmd->dbuf_p->data;
+	uint8_t			   *src_buf	 = (uint8_t *)cmd->dbuf_p->data + src_offset;
 	struct priv_lu_ssc *lu_priv;
 	uint32_t			crc;
 	int					rc;
@@ -718,7 +723,7 @@ static int writeBlock_zlib(struct scsi_cmd *cmd, uint32_t src_sz, uint8_t null_w
 	return src_len;
 }
 
-int writeBlock(struct scsi_cmd *cmd, uint32_t src_sz) {
+int writeBlock(struct scsi_cmd *cmd, uint32_t src_sz, uint32_t src_offset) {
 	struct priv_lu_ssc *lu_priv;
 	int					src_len;
 	uint64_t			current_position;
@@ -772,20 +777,20 @@ int writeBlock(struct scsi_cmd *cmd, uint32_t src_sz) {
 
 	if (lu_priv->mamp->MediumType == MEDIA_TYPE_NULL) {
 		/* Don't compress if null tape media */
-		src_len = writeBlock_nocomp(cmd, lbp_sz, TRUE, 0);
+		src_len = writeBlock_nocomp(cmd, lbp_sz, src_offset, TRUE, 0);
 	} else if (*lu_priv->compressionFactor == MHVTL_NO_COMPRESSION) {
 		/* No compression - use the no-compression function */
-		src_len = writeBlock_nocomp(cmd, lbp_sz, FALSE, lbp_method);
+		src_len = writeBlock_nocomp(cmd, lbp_sz, src_offset, FALSE, lbp_method);
 	} else {
 		switch (lu_priv->compressionType) {
 		case LZO:
-			src_len = writeBlock_lzo(cmd, lbp_sz, FALSE, lbp_method);
+			src_len = writeBlock_lzo(cmd, lbp_sz, src_offset, FALSE, lbp_method);
 			break;
 		case ZLIB:
-			src_len = writeBlock_zlib(cmd, lbp_sz, FALSE, lbp_method);
+			src_len = writeBlock_zlib(cmd, lbp_sz, src_offset, FALSE, lbp_method);
 			break;
 		default:
-			src_len = writeBlock_nocomp(cmd, lbp_sz, FALSE, lbp_method);
+			src_len = writeBlock_nocomp(cmd, lbp_sz, src_offset, FALSE, lbp_method);
 			break;
 		}
 	}

--- a/usr/mode.c
+++ b/usr/mode.c
@@ -689,10 +689,30 @@ int add_mode_medium_partition(struct lu_phy_attr *lu) {
 void set_medium_partition(struct scsi_cmd *cmd, uint8_t *p) {
 	struct lu_phy_attr *lu = cmd->lu;
 	struct mode		   *mp = lookup_mode_pg(&lu->mode_pg, MODE_MEDIUM_PARTITION, 0);
+	unsigned int		partitions;
 
-	/* ADDITIONAL PARTITIONS DEFINED */
-	mp->pcodePointer[3] = p[3];
-	mam.num_partitions	= mp->pcodePointer[3] + 1;
+	/* Drives which do not carry the page cannot be partitioned */
+	if (!mp) {
+		MHVTL_DBG(1, "No medium partition page - ignoring MODE SELECT");
+		return;
+	}
+
+	/* ADDITIONAL PARTITIONS DEFINED.
+	 *
+	 * The field is only restricted to 00h-03h when SDP or IDP is set; with
+	 * FDP set it is ignored and any value is legal, so it must be clamped
+	 * rather than rejected. The page holds MAX_PARTITIONS size descriptors
+	 * and the per-partition arrays are MAX_PARTITIONS deep.
+	 */
+	partitions = (unsigned int)p[3] + 1;
+	if (partitions > MAX_PARTITIONS) {
+		MHVTL_DBG(1, "ADDITIONAL PARTITIONS DEFINED %u exceeds %d - clamping",
+				  p[3], MAX_PARTITIONS - 1);
+		partitions = MAX_PARTITIONS;
+	}
+
+	mp->pcodePointer[3] = partitions - 1;
+	mam.num_partitions	= partitions;
 	MHVTL_DBG(3, "New total number of partitions : %d", mam.num_partitions);
 
 	mp->pcodePointer[4] = p[4]; /* flags */
@@ -700,7 +720,7 @@ void set_medium_partition(struct scsi_cmd *cmd, uint8_t *p) {
 	mp->pcodePointer[6] = p[6]; /* PARTITIONING TYPE | PARTITION UNITS */
 
 	/* PARTITION SIZES - two bytes each, not one */
-	for (int k = 0; k < mam.num_partitions; k++) {
+	for (unsigned int k = 0; k < partitions; k++) {
 		put_unaligned_be16(get_unaligned_be16(&p[8 + (2 * k)]),
 						   &mp->pcodePointer[8 + (2 * k)]);
 	}

--- a/usr/ssc.c
+++ b/usr/ssc.c
@@ -404,7 +404,6 @@ uint8_t ssc_read_6(struct scsi_cmd *cmd) {
 uint8_t ssc_write_6(struct scsi_cmd *cmd) {
 	declare_ssc_vars;
 
-	int retval = 0;
 	int count;
 	int sz;
 	int k;
@@ -435,9 +434,13 @@ uint8_t ssc_write_6(struct scsi_cmd *cmd) {
 	if (OK_to_write) {
 		update_volume_change_reference(lu_priv, sam_stat);
 
+		/* Each iteration must write the k'th block of the transfer, so the
+		 * offset into the command buffer has to be passed down: writeBlock()
+		 * always reads from cmd->dbuf_p->data, so advancing a local pointer
+		 * here would leave every block a copy of the first.
+		 */
 		for (k = 0; k < count; k++) {
-			retval = writeBlock(cmd, sz);
-			buf += retval;
+			writeBlock(cmd, sz, (uint32_t)k * sz);
 
 			if (*sam_stat)
 				return *sam_stat;
@@ -693,7 +696,10 @@ uint8_t ssc_locate(struct scsi_cmd *cmd) {
 		return SAM_STAT_CHECK_CONDITION;
 	}
 
-	if ((cdb[1] & 0b00000010) && partition_no > mam.num_partitions) {
+	/* Partition numbers are zero based, so num_partitions is one past the
+	 * last valid partition.
+	 */
+	if ((cdb[1] & 0b00000010) && partition_no >= mam.num_partitions) {
 		sam_illegal_request(E_INVALID_FIELD_IN_CDB,
 							NULL, sam_stat);
 		return SAM_STAT_CHECK_CONDITION;

--- a/usr/vtlcart.c
+++ b/usr/vtlcart.c
@@ -812,10 +812,17 @@ static int open_partition(uint8_t partition_number) {
 	char		 pcl_data[1024], pcl_indx[1024], pcl_meta[1024];
 	const char	*pcl_files[3] = {pcl_data, pcl_indx, pcl_meta};
 	struct stat	 data_stat, indx_stat, meta_stat;
-	struct stat *stats[3]	= {&data_stat, &indx_stat, &meta_stat};
-	int			*fd_open[3] = {&datafile[partition_number],
-							   &indxfile[partition_number],
-							   &metafile[partition_number]};
+	struct stat *stats[3] = {&data_stat, &indx_stat, &meta_stat};
+	int			*fd_open[3];
+
+	if (partition_number >= MAX_PARTITIONS) {
+		MHVTL_ERR("Partition %d out of range", partition_number);
+		return 3;
+	}
+
+	fd_open[0] = &datafile[partition_number];
+	fd_open[1] = &indxfile[partition_number];
+	fd_open[2] = &metafile[partition_number];
 
 	snprintf(pcl_data, ARRAY_SIZE(pcl_data), "%s/data.%d", currentPCL, partition_number);
 	snprintf(pcl_indx, ARRAY_SIZE(pcl_indx), "%s/indx.%d", currentPCL, partition_number);
@@ -837,9 +844,14 @@ static int open_partition(uint8_t partition_number) {
 }
 
 static void close_partition(uint8_t partition_number) {
-	int *fd_close[3] = {&datafile[partition_number],
-						&indxfile[partition_number],
-						&metafile[partition_number]};
+	int *fd_close[3];
+
+	if (partition_number >= MAX_PARTITIONS)
+		return;
+
+	fd_close[0] = &datafile[partition_number];
+	fd_close[1] = &indxfile[partition_number];
+	fd_close[2] = &metafile[partition_number];
 	for (int i = 0; i < 3; i++) {
 		if (*fd_close[i] >= 0) {
 			close(*fd_close[i]);
@@ -856,6 +868,11 @@ int change_partition(uint8_t partition_number) {
 	 */
 	uint8_t sam_stat = SAM_STAT_GOOD;
 	int		rc		 = 0;
+
+	if (partition_number >= MAX_PARTITIONS) {
+		MHVTL_ERR("Partition %d out of range", partition_number);
+		return 1;
+	}
 
 	close_partition(c_pos->partition_id);
 	c_pos->partition_id = partition_number;
@@ -1268,10 +1285,17 @@ int load_tape(const char *pcl, uint8_t *sam_stat) {
 		}
 	}
 
-	/* load all partitions */
+	/* Load all partitions. The per-partition state is MAX_PARTITIONS deep,
+	 * so stop there however many data.N files the cartridge directory holds.
+	 */
 	mam.num_partitions = 0;
 	snprintf(path, ARRAY_SIZE(path), "%s/data.%d", currentPCL, mam.num_partitions);
 	while (access(path, F_OK) == 0) {
+		if (mam.num_partitions >= MAX_PARTITIONS) {
+			MHVTL_ERR("pcl %s has more than %d partitions - ignoring the rest",
+					  pcl, MAX_PARTITIONS);
+			break;
+		}
 		c_pos->partition_id = mam.num_partitions;
 		load_partition(pcl, sam_stat, error_check, mam.num_partitions);
 		snprintf(path, ARRAY_SIZE(path), "%s/data.%d", currentPCL, ++mam.num_partitions);
@@ -1326,6 +1350,11 @@ int format_tape(uint8_t *sam_stat) {
 	}
 
 	/* Create <mam.num_partitions> partitions */
+	if (mam.num_partitions > MAX_PARTITIONS) {
+		MHVTL_ERR("num_partitions %d exceeds %d - clamping",
+				  mam.num_partitions, MAX_PARTITIONS);
+		mam.num_partitions = MAX_PARTITIONS;
+	}
 	for (int j = 0; j < mam.num_partitions; ++j) {
 		create_partition(j);
 	}


### PR DESCRIPTION
`ssc_write_6()` loops `writeBlock()` once per block, but `writeBlock()` always reads from the start of `cmd->dbuf_p->data`; the loop only advanced a local pointer that nothing used. A fixed-block WRITE(6) with N blocks therefore stored N copies of the first block. `writeBlock()` now takes the source offset and the loop passes `k * sz`.

Related fixes found while looking at this path:

- LBP CRC32C (method 2) was appended with `memcpy` in host byte order; protection information is big-endian on the wire, so use `put_unaligned_be32`.
- `readBlock()` with LBP RS-CRC continued after `BlockProtectRSCRC()` returned 0 and then indexed `bounce_buffer[rc - 4]`, i.e. before the buffer. It now returns a hardware error (LOGICAL BLOCK GUARD CHECK FAILED).
- Partition indices are bounded to `MAX_PARTITIONS` everywhere they index the per-partition arrays: MODE SELECT medium partition page (ADDITIONAL PARTITIONS DEFINED clamped; missing page handled), `open/close/change_partition`, `load_tape` (extra `data.N` files ignored), `format_tape`. LOCATE with CP set rejected `partition_no > num_partitions`; partitions are zero-based, so the check is now `>=`.

Build-tested on the current master; the WRITE(6) fix is mechanical.