### PR TITLE
fix(daemons): keep signal handlers and drive IPC safe

### DIFF
--- a/usr/cmd/vtllibrary.c
+++ b/usr/cmd/vtllibrary.c
@@ -1470,14 +1470,23 @@ static void customise_lu(struct lu_phy_attr *lu) {
 		init_default_smc(lu);
 }
 
+static volatile sig_atomic_t reread_config_requested;
+
+/* SIGHUP handler: only raise a flag. The re-initialisation itself runs
+ * from the main loop, where no command is part way through.
+ */
 void rereadconfig(int sig) {
+	(void)sig;
+	reread_config_requested = 1;
+}
+
+static void do_rereadconfig(void) {
 	struct mhvtl_ctl ctl;
 	int				 buffer_size;
 
 	lunit.online = 0; /* Report library offline until finished */
 
-	MHVTL_DBG(1, "Caught signal (%d): Re-initialising library %d",
-			  sig, (int)my_id);
+	MHVTL_DBG(1, "Re-initialising library %d", (int)my_id);
 
 	cleanup_lu(&lunit);
 
@@ -1836,6 +1845,11 @@ int main(int argc, char *argv[]) {
 				break;
 
 			case VTL_IDLE:
+				if (reread_config_requested) {
+					reread_config_requested = 0;
+					do_rereadconfig();
+					buffer_size = smc_slots.bufsize;
+				}
 				usleep(pollInterval);
 
 				if (pollInterval < 1000000)

--- a/usr/cmd/vtltape.c
+++ b/usr/cmd/vtltape.c
@@ -266,8 +266,20 @@ int lookup_mode_media_type(struct name_to_media_info *media_info, int med) {
 	return media_type_unknown;
 }
 
+static volatile sig_atomic_t mount_complete;
+
+/* Only raise a flag here - apply_mount_complete() does the work from the
+ * main loop, where the log pages are not being read by a command.
+ */
 static void finish_mount(int sig) {
-	MHVTL_DBG(3, "+++ Trace - Received signal %d +++", sig);
+	(void)sig;
+	mount_complete = 1;
+}
+
+static void apply_mount_complete(void) {
+	if (!mount_complete)
+		return;
+	mount_complete = 0;
 	if (get_tape_load_status() == TAPE_LOADING)
 		set_tape_load_status(TAPE_LOADED);
 }
@@ -283,10 +295,12 @@ void delay_opcode(int what, int value) {
 
 	switch (what) {
 	case DELAY_LOAD:
-		if (value)
+		if (value) {
 			set_mount_timer(value);
-		else
-			finish_mount(1);
+		} else {
+			mount_complete = 1;
+			apply_mount_complete();
+		}
 		break;
 	default:
 		sleep(value);
@@ -2207,10 +2221,21 @@ void ssc_personality_module_register(struct ssc_personality_template *pm) {
 	}
 }
 
+/* Neither printf() nor syslog() is async-signal-safe, so just note the
+ * signal and let the main loop report it.
+ */
+static volatile sig_atomic_t caught_signo;
+
 static void caught_signal(int signo) {
-	printf("Please use 'vtlcmd <index> exit' to shutdown nicely\n"
-		   " Received signal: %d\n\n",
-		   signo);
+	caught_signo = signo;
+}
+
+static void report_caught_signal(void) {
+	int signo = caught_signo;
+
+	if (!signo)
+		return;
+	caught_signo = 0;
 	MHVTL_LOG("Please use 'vtlcmd <index> exit' to shutdown nicely,"
 			  " Received signal: %d",
 			  signo);
@@ -2494,6 +2519,8 @@ int main(int argc, char *argv[]) {
 				break;
 
 			case VTL_IDLE:
+				apply_mount_complete();
+				report_caught_signal();
 				usleep(sleep_time);
 
 				/* While nothing to do, increase

--- a/usr/smc.c
+++ b/usr/smc.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include <inttypes.h>
 #include "be_byteshift.h"
 #include "mhvtl_scsi.h"
@@ -159,12 +160,20 @@ static int is_drive_empty(struct d_info *drv) {
 			  my_id, msg_mount_state, drv->drv_id);
 	send_msg(msg_mount_state, drv->drv_id);
 
+	/* A failed receive leaves q untouched, so it must not be read */
+	memset(&q, 0, sizeof(q));
+
 	mlen = msgrcv(r_qid, &q, MAXOBN, my_id, MSG_NOERROR);
-	if (mlen > 0)
-		MHVTL_DBG(1, "%ld: Received \"%s\" from snd_id %ld",
-				  my_id,
-				  q.msg.text,
-				  q.msg.snd_id);
+	if (mlen <= 0) {
+		MHVTL_ERR("%ld: No reply from the drive: %s",
+				  my_id, strerror(errno));
+		return 1; /* Assume occupied rather than act on garbage */
+	}
+
+	MHVTL_DBG(1, "%ld: Received \"%s\" from snd_id %ld",
+			  my_id,
+			  q.msg.text,
+			  q.msg.snd_id);
 
 	/* string defined in q.h */
 	return strncmp(msg_not_occupied, q.msg.text, 12);
@@ -201,12 +210,20 @@ static int check_tape_unload(void) {
 		exit(1);
 	}
 
+	/* A failed receive leaves q untouched, so it must not be read */
+	memset(&q, 0, sizeof(q));
+
 	mlen = msgrcv(r_qid, &q, MAXOBN, my_id, MSG_NOERROR);
-	if (mlen > 0)
-		MHVTL_DBG(1, "%ld: Received \"%s\" from snd_id %ld",
-				  my_id,
-				  q.msg.text,
-				  q.msg.snd_id);
+	if (mlen <= 0) {
+		MHVTL_ERR("%ld: No reply from the drive: %s",
+				  my_id, strerror(errno));
+		return 1; /* Treat as an unload failure */
+	}
+
+	MHVTL_DBG(1, "%ld: Received \"%s\" from snd_id %ld",
+			  my_id,
+			  q.msg.text,
+			  q.msg.snd_id);
 
 	/* msg defined in q.h */
 	return strncmp(msg_unload_ok, q.msg.text, 11);
@@ -977,12 +994,20 @@ static int check_tape_load(void) {
 		exit(1);
 	}
 
+	/* A failed receive leaves q untouched, so it must not be read */
+	memset(&q, 0, sizeof(q));
+
 	mlen = msgrcv(r_qid, &q, MAXOBN, my_id, MSG_NOERROR);
-	if (mlen > 0)
-		MHVTL_DBG(1, "%ld: Received \"%s\" from snd_id %ld",
-				  my_id,
-				  q.msg.text,
-				  q.msg.snd_id);
+	if (mlen <= 0) {
+		MHVTL_ERR("%ld: No reply from the drive: %s",
+				  my_id, strerror(errno));
+		return 1; /* Treat as a load failure */
+	}
+
+	MHVTL_DBG(1, "%ld: Received \"%s\" from snd_id %ld",
+			  my_id,
+			  q.msg.text,
+			  q.msg.snd_id);
 
 	/* msg defined in q.h */
 	return strncmp(msg_load_ok, q.msg.text, strlen(msg_load_ok));

--- a/usr/utils/subprocess.c
+++ b/usr/utils/subprocess.c
@@ -27,22 +27,29 @@
 #include <signal.h>
 #include "logging.h"
 
-static pid_t pid;
-static int	 timedout;
+static volatile sig_atomic_t pid;
+static volatile sig_atomic_t timedout;
 
 void alarm_timeout(int sig) {
+	(void)sig;
 	alarm(0);
 	timedout = 1;
+	/* pid is cleared before the child is reaped, so this cannot signal a
+	 * pid the system has already recycled.
+	 */
 	if (pid)
-		kill(pid, 9);
+		kill((pid_t)pid, SIGKILL);
 }
 
 int run_command(char *command, int timeout) {
-	pid = fork();
-	if (!pid) {
+	pid_t child = fork();
+
+	pid = child;
+	if (!child) {
 		/* child */
 		execlp("/bin/sh", "/bin/sh", "-c", command, (char *)NULL);
-	} else if (pid < 0) {
+		_exit(127); /* execlp only returns on failure */
+	} else if (child < 0) {
 		/* TODO error handling */
 		return -1;
 	} else {
@@ -51,10 +58,11 @@ int run_command(char *command, int timeout) {
 		alarm(timeout);
 		int status;
 
-		while (waitpid(pid, &status, 0) <= 0)
+		while (waitpid(child, &status, 0) <= 0)
 			usleep(1);
 
 		alarm(0);
+		pid = 0;
 
 		if (WIFEXITED(status)) {
 			int res = WEXITSTATUS(status);


### PR DESCRIPTION
- `vtllibrary`: SIGHUP tore down and rebuilt the whole library from inside the handler. The handler now only sets a flag; the re-initialisation runs from the main loop while idle.
- `vtltape`: the mount timer (SIGALRM) updated the load state and log pages from the handler, and the "please use vtlcmd exit" handler called `printf()`. Both now set a flag that the idle loop acts on.
- `smc.c`: the three library-to-drive requests (`is_drive_empty`, `check_tape_load`, `check_tape_unload`) read the message buffer even when `msgrcv()` failed, i.e. stale or uninitialised data. A failed receive is now logged and treated as occupied / load failed / unload failed.
- `subprocess.c`: `pid`/`timedout` are `volatile sig_atomic_t`, `pid` is cleared before the child is reaped so the alarm cannot signal a recycled pid, and a failed `execlp()` `_exit(127)`s instead of returning into the parent's code.

## Testing

Built on current master and run on Ubuntu 26.04 (kernel 7.0), L700 library with ULT3580-TD9 and ULT3580-TDA drives, daemons run from the build tree.

| Changed path | Test | Result |
|---|---|---|
| Baseline | `mtx` load, 64 x 64 KiB write/read, unload | data identical |
| SIGALRM mount timer -> flag -> main loop | `vtlcmd 11 delay load 6`, `mtx load`, poll TEST UNIT READY | "becoming ready" for 6.3 s, then GOOD; with delay 0 ready after 28 ms |
| vtltape signal handler only sets a flag | SIGINT, SIGTERM, SIGUSR1, SIGHUP sent to the drive | daemon survives all four; advice line logged from the main loop; drive keeps answering |
| SIGHUP re-init from the main loop | SIGHUP while idle; then 25 SIGHUPs while `mtx status` runs in a loop | library alive, inventory intact, load/unload works afterwards |
| `run_command` alarm path | `movecommand` pointing at a 30 s script with `commandtimeout: 2`, applied via SIGHUP reread | MOVE MEDIUM fails after 2 s ("move command returned -9"), library alive; a fast script works |
| failed `msgrcv` in the library | drive daemon frozen with SIGSTOP, IPC queue removed during the request | library logs `No reply from the drive: Identifier removed`, reports the drive as occupied and stays alive |