### PR TITLE
fix(vtlcmd): return a value from Check_Params on every path

### DIFF
--- a/usr/cmd/vtlcmd.c
+++ b/usr/cmd/vtlcmd.c
@@ -272,10 +272,8 @@ const char *Check_Params(int argc, char **argv) {
 			}
 			if (!strcmp(argv[2], "exit")) {
 				if (argc == 3)
-					return;
-			}
-			if (!strncasecmp(argv[2], "InquiryDataChange", 17)) {
-				return;
+					return NULL;
+				return "exit";
 			}
 			if (!strncasecmp(argv[2], "InquiryDataChange", 17))
 				return NULL;


### PR DESCRIPTION
`master` does not build: `Check_Params()` returns `const char *`, but two paths return without a value, which gcc rejects with `-Wreturn-mismatch`.

```
cmd/vtlcmd.c:275:41: error: 'return' with no value, in function returning non-void
cmd/vtlcmd.c:278:33: error: 'return' with no value, in function returning non-void
make[1]: *** [Makefile:88: cmd/vtlcmd.o] Error 1
```

The function was converted from `void` (using `PrintErrorExit()`) to returning an error string, where accept is `NULL` and reject is a message. Two cases were not converted:

- `exit`: `return;` became unreachable as a value, and the reject path `PrintErrorExit(argv[0], "exit")` was dropped, so `vtlcmd <n> exit <extra>` falls through to the generic `check param` message instead of naming the command.
- `InquiryDataChange`: the original block was left in place next to its converted replacement, so the condition is evaluated twice and the first copy returns without a value.

Changes:

- Return `NULL` for a well-formed `exit`, and `"exit"` otherwise, consistent with `verbose`, `dump` and `debug` above it.
- Remove the duplicated `InquiryDataChange` block; the converted line below it already handles that case.

These are the only value-less returns in a non-void function in `usr/`; all twelve `Check_*` functions return `const char *`.

Tested on Ubuntu 26.04 with gcc: `make` completes with no errors, `make -C tests` builds, and `tests/test_vtlcmd_parsing` passes.
