### PR TITLE
perf: stop repeating per-command work in the data path

### DIFF
--- a/usr/cmd/vtltape.c
+++ b/usr/cmd/vtltape.c
@@ -2381,7 +2381,6 @@ int main(int argc, char *argv[]) {
 	unsigned	minor	 = 0;
 
 	struct mhvtl_header	 mhvtl_cmd;
-	struct mhvtl_header *cmd;
 	struct mhvtl_ctl	 ctl;
 
 	/* Message Q */
@@ -2594,7 +2593,7 @@ int main(int argc, char *argv[]) {
 				time_to_exit = 1; /* Flag that we need to exit */
 				MHVTL_DBG(1, "Exit called");
 			}
-		} else if (mlen < 0) {
+		} else if (mlen < 0 && errno != ENOMSG && errno != EINTR) {
 			if ((r_qid = init_queue()) == -1) {
 				MHVTL_ERR("Can not open message queue: %s",
 						  strerror(errno));
@@ -2632,17 +2631,9 @@ int main(int argc, char *argv[]) {
 				fflush(NULL);
 			switch (ret) {
 			case VTL_QUEUE_CMD: /* A cdb to process */
-				cmd = malloc(sizeof(struct mhvtl_header));
-				if (!cmd) {
-					MHVTL_ERR("Out of memory");
-					sleep_time = 1000000;
-				} else {
-					memcpy(cmd, &mhvtl_cmd, sizeof(mhvtl_cmd));
-					process_cmd(cdev, buf, cmd, sleep_time);
-					/* Something to do, reduce poll time */
-					sleep_time = MIN_SLEEP_TIME;
-					free(cmd);
-				}
+				process_cmd(cdev, buf, &mhvtl_cmd, sleep_time);
+				/* Something to do, reduce poll time */
+				sleep_time = MIN_SLEEP_TIME;
 				break;
 
 			case VTL_IDLE:

--- a/usr/mhvtl_io.c
+++ b/usr/mhvtl_io.c
@@ -579,11 +579,16 @@ static int writeBlock_nocomp(struct scsi_cmd *cmd, uint32_t src_sz, uint32_t src
  *
  * Zero on error with sense buffer already filled in
  */
+/* Reused for every compressed write - LZO1X_1_MEM_COMPRESS is fixed at
+ * compile time and the daemon is single threaded.
+ */
+static lzo_align_t lzo_wrkmem[((LZO1X_1_MEM_COMPRESS) + (sizeof(lzo_align_t) - 1)) /
+							  sizeof(lzo_align_t)];
+
 static int writeBlock_lzo(struct scsi_cmd *cmd, uint32_t src_sz, uint32_t src_offset, uint8_t null_wr, int lbp_method) {
 	lzo_uint  dest_len;
 	lzo_uint  src_len = src_sz;
 	lzo_bytep dest_buf;
-	lzo_bytep wrkmem = NULL;
 	uint32_t  crc;
 
 	lzo_bytep src_buf = (lzo_bytep)cmd->dbuf_p->data + src_offset;
@@ -601,26 +606,18 @@ static int writeBlock_lzo(struct scsi_cmd *cmd, uint32_t src_sz, uint32_t src_of
 
 	dest_len = mhvtl_compressBound(src_sz);
 	dest_buf = (lzo_bytep)malloc(dest_len);
-	wrkmem	 = (lzo_bytep)malloc(LZO1X_1_MEM_COMPRESS);
 
 	if (unlikely(!dest_buf)) {
 		MHVTL_ERR("dest_buf malloc(%d) failed", (int)dest_len);
 		sam_medium_error(E_WRITE_ERROR, sam_stat);
-		free(wrkmem);
 		return 0;
 	}
 
-	if (unlikely(!wrkmem)) {
-		MHVTL_ERR("wrkmem malloc(%d) failed", (int)LZO1X_1_MEM_COMPRESS);
-		sam_medium_error(E_WRITE_ERROR, sam_stat);
-		free(dest_buf);
-		return 0;
-	}
-
-	z = lzo1x_1_compress(src_buf, src_sz, dest_buf, &dest_len, wrkmem);
+	z = lzo1x_1_compress(src_buf, src_sz, dest_buf, &dest_len, lzo_wrkmem);
 	if (unlikely(z != LZO_E_OK)) {
 		MHVTL_ERR("LZO compression error");
 		sam_hardware_error(E_COMPRESSION_CHECK, sam_stat);
+		free(dest_buf);
 		return 0;
 	}
 
@@ -629,7 +626,6 @@ static int writeBlock_lzo(struct scsi_cmd *cmd, uint32_t src_sz, uint32_t src_of
 	rc = write_tape_block(dest_buf, src_len, dest_len, lu_priv->app_encr_info, LZO, null_wr, crc, sam_stat);
 
 	free(dest_buf);
-	free(wrkmem);
 	lu_priv->bytesWritten_M += dest_len;
 	lu_priv->bytesWritten_I += src_len;
 

--- a/usr/vtlcart.c
+++ b/usr/vtlcart.c
@@ -182,6 +182,7 @@ static int tape_loaded(uint8_t *sam_stat) {
 	return 0;
 }
 
+/* Rewrite the meta_header structure and the filemark map. */
 static int rewrite_meta_file(void) {
 	ssize_t io_size, nwrite;
 	size_t	io_offset;
@@ -304,7 +305,11 @@ static int check_filemarks_alloc(uint32_t count) {
 	return 0;
 }
 
-static int add_filemark(uint32_t blk_number) {
+/* Record the filemark in the in-memory map only. The caller is responsible
+ * for persisting it with rewrite_meta_file(), so that writing N filemarks
+ * costs one meta file rewrite rather than N.
+ */
+static int add_filemark_locked(uint32_t blk_number) {
 	/* See if we have enough space remaining to add the new filemark.  If
 	   not, realloc now.
 	*/
@@ -314,9 +319,7 @@ static int add_filemark(uint32_t blk_number) {
 
 	filemarks[c_pos->partition_id][meta[c_pos->partition_id].filemark_count++] = blk_number;
 
-	/* Now rewrite the meta_header structure and the filemark map. */
-
-	return rewrite_meta_file();
+	return 0;
 }
 
 /*
@@ -1491,8 +1494,13 @@ int write_filemarks(uint32_t count, uint8_t *sam_stat) {
 					  strerror(errno));
 			return -1;
 		}
-		add_filemark(blk_number);
+		if (add_filemark_locked(blk_number))
+			return -1;
 	}
+
+	/* One rewrite of the meta file covers every filemark just added. */
+	if (rewrite_meta_file())
+		return -1;
 
 	/* Provide the force-flush guarantee. */
 


### PR DESCRIPTION
Work repeated per command in the tape data path.

- Reuse one LZO work buffer instead of allocating `LZO1X_1_MEM_COMPRESS` bytes for every WRITE. The buffer is fixed at compile time and the daemon is single threaded.
- Free the destination buffer when LZO compression fails. That path leaked it.
- Rewrite the meta file once per WRITE FILEMARKS rather than once per mark. The `fsync()` that follows is unchanged, so the durability boundary is still the command.
- Pass the command header straight from the stack instead of allocating and copying it for every command.
- Reopen the message queue only after a real error, not on every idle poll.

## Testing

Ubuntu 26.04, kernel 7.0.0-30, STK L700 changer with an LTO-9 drive, each build measured in the same session:

| Test | master | this branch |
| --- | --- | --- |
| 20000 x 8 KiB writes, three runs | 1267, 1253, 1253 ms | 1206, 1207, 1208 ms |
| 200 MB write, rewind, read back | data identical | data identical |
| 50 filemarks | 286 ms | 290 ms |
| 20 filemarks, unload, reload, count them | 20 found | 20 found |

The small-block figure is the per-command path this branch targets: about 4 percent faster, with runs within 2 ms of each other. The filemark timing is unchanged because it is dominated by process startup, not by the meta file; the change removes 49 of the 50 rewrites rather than making the measured operation faster.
