### PR TITLE
refactor: share the VPD page allocation idiom

### DIFF
--- a/include/vtllib.h
+++ b/include/vtllib.h
@@ -816,6 +816,7 @@ void log_opcode(char *opcode, struct scsi_cmd *cmd);
 
 struct vpd *alloc_vpd(uint16_t sz);
 void		dealloc_vpd(struct vpd *pg);
+struct vpd *add_vpd_page(struct lu_phy_attr *lu, uint8_t pcode, uint16_t sz);
 void		cleanup_density_support(struct list_head *l);
 
 void completeSCSICommand(int, struct mhvtl_ds *ds);
@@ -866,7 +867,6 @@ void		 mam_space_remaining(struct MAM *mamp);
 char *slot_type_str(int type);
 void  init_smc_log_pages(struct lu_phy_attr *lu);
 void  init_smc_mode_pages(struct lu_phy_attr *lu);
-void  bubbleSort(int *array, int size);
 void  sort_library_slot_type(struct lu_phy_attr *lu, struct smc_type_slot *type);
 
 void ymd(int *year, int *month, int *day, int *hh, int *min, int *sec);

--- a/usr/cmd/vtlcmd.c
+++ b/usr/cmd/vtlcmd.c
@@ -385,18 +385,6 @@ const char *Check_DeviceCommand(const char *buf, int device_type) {
 }
 
 /* Open a new queue (for answers from server) */
-int CreateNewQueue(void) {
-	long queue_id;
-
-	/* Attempt to create a message queue */
-	queue_id = msgget(IPC_PRIVATE,
-					  IPC_CREAT | S_IRUSR | S_IWUSR | S_IWGRP | S_IWOTH);
-	if (queue_id == -1)
-		fprintf(stderr, "%s: %s\n", __func__, strerror(errno));
-
-	return queue_id;
-}
-
 /* Open an alreay opened queue (opened by server) */
 int OpenExistingQueue(key_t key) {
 	long queue_id;

--- a/usr/pm/ait_pm.c
+++ b/usr/pm/ait_pm.c
@@ -166,7 +166,6 @@ static int encr_capabilities_ait(struct scsi_cmd *cmd) {
 }
 
 static void init_ait_inquiry(struct lu_phy_attr *lu) {
-	int		pg;
 	uint8_t worm;
 	uint8_t local_TapeAlert[8] = {
 		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
@@ -176,48 +175,23 @@ static void init_ait_inquiry(struct lu_phy_attr *lu) {
 		((struct priv_lu_ssc *)lu->lu_private)->pm->drive_ANSI_VERSION;
 
 	/* Sequential Access device capabilities - Ref: 8.4.2 */
-	pg			   = PCODE_OFFSET(0xb0);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B0_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb0, VPD_B0_SZ);
 	update_vpd_b0(lu, &worm);
 
 	/* Manufacture-assigned serial number - Ref: 8.4.3 */
-	pg			   = PCODE_OFFSET(0xb1);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B1_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb1, VPD_B1_SZ);
 	update_vpd_b1(lu, lu->lu_serial_no);
 
 	/* TapeAlert supported flags - Ref: 8.4.4 */
-	pg			   = PCODE_OFFSET(0xb2);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B2_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb2, VPD_B2_SZ);
 	update_vpd_b2(lu, &local_TapeAlert);
 
 	/* VPD page 0xC0 */
-	pg			   = PCODE_OFFSET(0xc0);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_C0_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xc0, VPD_C0_SZ);
 	update_vpd_c0(lu, "10-03-2008 19:38:00");
 
 	/* VPD page 0xC1 */
-	pg			   = PCODE_OFFSET(0xc1);
-	lu->lu_vpd[pg] = alloc_vpd(strlen("Security"));
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xc1, strlen("Security"));
 	update_vpd_c1(lu, "Security");
 }
 

--- a/usr/pm/default_ssc_pm.c
+++ b/usr/pm/default_ssc_pm.c
@@ -258,7 +258,6 @@ static uint8_t clear_default_WORM(struct list_head *l) {
 }
 
 static void init_default_inquiry(struct lu_phy_attr *lu) {
-	int		pg;
 	uint8_t worm;
 	uint8_t local_TapeAlert[8] =
 		{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
@@ -268,48 +267,23 @@ static void init_default_inquiry(struct lu_phy_attr *lu) {
 		((struct priv_lu_ssc *)lu->lu_private)->pm->drive_ANSI_VERSION;
 
 	/* Sequential Access device capabilities - Ref: 8.4.2 */
-	pg			   = PCODE_OFFSET(0xb0);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B0_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb0, VPD_B0_SZ);
 	update_vpd_b0(lu, &worm);
 
 	/* Manufacture-assigned serial number - Ref: 8.4.3 */
-	pg			   = PCODE_OFFSET(0xb1);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B1_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb1, VPD_B1_SZ);
 	update_vpd_b1(lu, lu->lu_serial_no);
 
 	/* TapeAlert supported flags - Ref: 8.4.4 */
-	pg			   = PCODE_OFFSET(0xb2);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B2_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb2, VPD_B2_SZ);
 	update_vpd_b2(lu, &local_TapeAlert);
 
 	/* VPD page 0xC0 */
-	pg			   = PCODE_OFFSET(0xc0);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_C0_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xc0, VPD_C0_SZ);
 	update_vpd_c0(lu, "10-03-2008 19:38:00");
 
 	/* VPD page 0xC1 */
-	pg			   = PCODE_OFFSET(0xc1);
-	lu->lu_vpd[pg] = alloc_vpd(strlen("Security"));
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xc1, strlen("Security"));
 	update_vpd_c1(lu, "Security");
 }
 

--- a/usr/pm/hp_ultrium_pm.c
+++ b/usr/pm/hp_ultrium_pm.c
@@ -253,7 +253,6 @@ static void update_hp_vpd_cx(struct lu_phy_attr *lu, uint8_t pg, char *comp,
 }
 
 static void init_ult_inquiry(struct lu_phy_attr *lu) {
-	int		pg;
 	uint8_t worm;
 	uint8_t local_TapeAlert[8] =
 		{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
@@ -264,99 +263,49 @@ static void init_ult_inquiry(struct lu_phy_attr *lu) {
 
 	lu->inquiry[40] = worm; /* Reference 3.7.1 HP Ultrium ISV Cookbook */
 
-	pg			   = PCODE_OFFSET(0x86);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_86_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0x86, VPD_86_SZ);
 	update_vpd_86(lu, ((struct priv_lu_ssc *)lu->lu_private)->pm);
 
 	/* Sequential Access device capabilities - Ref: 8.4.2 */
-	pg			   = PCODE_OFFSET(0xb0);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B0_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb0, VPD_B0_SZ);
 	update_vpd_b0(lu, &worm);
 
 	/* Manufacture-assigned serial number - Ref: 8.4.3 */
-	pg			   = PCODE_OFFSET(0xb1);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B1_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb1, VPD_B1_SZ);
 	update_vpd_b1(lu, lu->lu_serial_no);
 
 	/* TapeAlert supported flags - Ref: 8.4.4 */
-	pg			   = PCODE_OFFSET(0xb2);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B2_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb2, VPD_B2_SZ);
 	update_vpd_b2(lu, &local_TapeAlert);
 
 	/* VPD page 0xC0 - Firmware revision page */
-	pg			   = PCODE_OFFSET(0xc0);
-	lu->lu_vpd[pg] = alloc_vpd(0x60);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
-	update_hp_vpd_cx(lu, pg, "Firmware", MHVTL_VERSION,
+	add_vpd_page(lu, 0xc0, 0x60);
+	update_hp_vpd_cx(lu, 0xc0, "Firmware", MHVTL_VERSION,
 					 "2012/04/18 19:38", "6");
 
 	/* VPD page 0xC1 - Hardware */
-	pg			   = PCODE_OFFSET(0xc1);
-	lu->lu_vpd[pg] = alloc_vpd(0x60);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
-	update_hp_vpd_cx(lu, pg, "Hardware", MHVTL_VERSION,
+	add_vpd_page(lu, 0xc1, 0x60);
+	update_hp_vpd_cx(lu, 0xc1, "Hardware", MHVTL_VERSION,
 					 "2012/04/18 06:53", "5");
 
 	/* VPD page 0xC2 - PCA */
-	pg			   = PCODE_OFFSET(0xc2);
-	lu->lu_vpd[pg] = alloc_vpd(0x60);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
-	update_hp_vpd_cx(lu, pg, "PCA", MHVTL_VERSION,
+	add_vpd_page(lu, 0xc2, 0x60);
+	update_hp_vpd_cx(lu, 0xc2, "PCA", MHVTL_VERSION,
 					 "1996/11/29 10:00", "4");
 
 	/* VPD page 0xC3 - Mechanism */
-	pg			   = PCODE_OFFSET(0xc3);
-	lu->lu_vpd[pg] = alloc_vpd(0x60);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
-	update_hp_vpd_cx(lu, pg, "Mechanism", MHVTL_VERSION,
+	add_vpd_page(lu, 0xc3, 0x60);
+	update_hp_vpd_cx(lu, 0xc3, "Mechanism", MHVTL_VERSION,
 					 "1992/08/11 10:00", "3");
 
 	/* VPD page 0xC4 - Head Assembly */
-	pg			   = PCODE_OFFSET(0xc4);
-	lu->lu_vpd[pg] = alloc_vpd(0x60);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
-	update_hp_vpd_cx(lu, pg, "Head Assy", MHVTL_VERSION,
+	add_vpd_page(lu, 0xc4, 0x60);
+	update_hp_vpd_cx(lu, 0xc4, "Head Assy", MHVTL_VERSION,
 					 "1966/07/28 10:00", "2");
 
 	/* VPD page 0xC5 - ACI */
-	pg			   = PCODE_OFFSET(0xc5);
-	lu->lu_vpd[pg] = alloc_vpd(0x60);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
-	update_hp_vpd_cx(lu, pg, "ACI", MHVTL_VERSION,
+	add_vpd_page(lu, 0xc5, 0x60);
+	update_hp_vpd_cx(lu, 0xc5, "ACI", MHVTL_VERSION,
 					 "1960/03/10 10:00", "1");
 }
 

--- a/usr/pm/ibm_03592_pm.c
+++ b/usr/pm/ibm_03592_pm.c
@@ -226,7 +226,6 @@ static int encr_capabilities_3592(struct scsi_cmd *cmd) {
 }
 
 static void init_3592_inquiry(struct lu_phy_attr *lu) {
-	int		pg;
 	uint8_t worm;
 	uint8_t local_TapeAlert[8] =
 		{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
@@ -236,48 +235,23 @@ static void init_3592_inquiry(struct lu_phy_attr *lu) {
 		((struct priv_lu_ssc *)lu->lu_private)->pm->drive_ANSI_VERSION;
 
 	/* Sequential Access device capabilities - Ref: 8.4.2 */
-	pg			   = PCODE_OFFSET(0xb0);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B0_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb0, VPD_B0_SZ);
 	update_vpd_b0(lu, &worm);
 
 	/* Manufacture-assigned serial number - Ref: 8.4.3 */
-	pg			   = PCODE_OFFSET(0xb1);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B1_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb1, VPD_B1_SZ);
 	update_vpd_b1(lu, lu->lu_serial_no);
 
 	/* TapeAlert supported flags - Ref: 8.4.4 */
-	pg			   = PCODE_OFFSET(0xb2);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B2_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb2, VPD_B2_SZ);
 	update_vpd_b2(lu, &local_TapeAlert);
 
 	/* VPD page 0xC0 */
-	pg			   = PCODE_OFFSET(0xc0);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_C0_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xc0, VPD_C0_SZ);
 	update_vpd_c0(lu, "10-03-2008 19:38:00");
 
 	/* VPD page 0xC1 */
-	pg			   = PCODE_OFFSET(0xc1);
-	lu->lu_vpd[pg] = alloc_vpd(strlen("Security"));
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xc1, strlen("Security"));
 	update_vpd_c1(lu, "Security");
 }
 

--- a/usr/pm/quantum_dlt_pm.c
+++ b/usr/pm/quantum_dlt_pm.c
@@ -176,7 +176,6 @@ static uint8_t clear_dlt_WORM(struct list_head *m) {
 
 /* DLT7000 & DLT8000 */
 static void init_dlt_inquiry(struct lu_phy_attr *lu) {
-	int	 pg;
 	char b[32];
 	int	 x, y, z;
 
@@ -196,27 +195,16 @@ static void init_dlt_inquiry(struct lu_phy_attr *lu) {
 	}
 
 	/* VPD page 0xC0 */
-	pg			   = PCODE_OFFSET(0xc0);
-	lu->lu_vpd[pg] = alloc_vpd(44);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xc0, 44);
 	update_vpd_dlt_c0(lu);
 
 	/* VPD page 0xC1 */
-	pg			   = PCODE_OFFSET(0xc1);
-	lu->lu_vpd[pg] = alloc_vpd(44);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xc1, 44);
 	update_vpd_dlt_c1(lu, lu->lu_serial_no);
 }
 
 /* SuperDLT range */
 static void init_sdlt_inquiry(struct lu_phy_attr *lu) {
-	int		pg;
 	uint8_t worm;
 	uint8_t ta[8] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 	char	b[32];
@@ -239,48 +227,23 @@ static void init_sdlt_inquiry(struct lu_phy_attr *lu) {
 	}
 
 	/* Sequential Access device capabilities - Ref: 8.4.2 */
-	pg			   = PCODE_OFFSET(0xb0);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B0_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb0, VPD_B0_SZ);
 	update_vpd_b0(lu, &worm);
 
 	/* Manufacture-assigned serial number - Ref: 8.4.3 */
-	pg			   = PCODE_OFFSET(0xb1);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B1_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb1, VPD_B1_SZ);
 	update_vpd_b1(lu, lu->lu_serial_no);
 
 	/* TapeAlert supported flags - Ref: 8.4.4 */
-	pg			   = PCODE_OFFSET(0xb2);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B2_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb2, VPD_B2_SZ);
 	update_vpd_b2(lu, &ta);
 
 	/* VPD page 0xC0 */
-	pg			   = PCODE_OFFSET(0xc0);
-	lu->lu_vpd[pg] = alloc_vpd(44);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xc0, 44);
 	update_vpd_dlt_c0(lu);
 
 	/* VPD page 0xC1 */
-	pg			   = PCODE_OFFSET(0xc1);
-	lu->lu_vpd[pg] = alloc_vpd(44);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xc1, 44);
 	update_vpd_dlt_c1(lu, lu->lu_serial_no);
 }
 

--- a/usr/pm/stk9x40_pm.c
+++ b/usr/pm/stk9x40_pm.c
@@ -324,7 +324,6 @@ static struct ssc_personality_template ssc_pm = {
 
 #define INQUIRY_LEN 74
 static void init_9840_inquiry(struct lu_phy_attr *lu) {
-	int		pg;
 	uint8_t worm;
 
 	worm = ((struct priv_lu_ssc *)lu->lu_private)->pm->drive_supports_WORM;
@@ -337,12 +336,7 @@ static void init_9840_inquiry(struct lu_phy_attr *lu) {
 	lu->inquiry[55] = 0x12;			   /* Support Encryption & Compression */
 
 	/* Sequential Access device capabilities - Ref: 8.4.2 */
-	pg			   = PCODE_OFFSET(0xb0);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B0_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb0, VPD_B0_SZ);
 	update_vpd_b0(lu, &worm);
 }
 

--- a/usr/pm/t10000_pm.c
+++ b/usr/pm/t10000_pm.c
@@ -388,7 +388,6 @@ static struct ssc_personality_template ssc_pm = {
 
 #define INQUIRY_LEN 74
 static void init_t10k_inquiry(struct lu_phy_attr *lu) {
-	int		pg;
 	uint8_t worm;
 
 	worm = ((struct priv_lu_ssc *)lu->lu_private)->pm->drive_supports_WORM;
@@ -419,12 +418,7 @@ static void init_t10k_inquiry(struct lu_phy_attr *lu) {
 	put_unaligned_be16(0x0a11, &lu->inquiry[64]);
 
 	/* Sequential Access device capabilities - Ref: 8.4.2 */
-	pg			   = PCODE_OFFSET(0xb0);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B0_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb0, VPD_B0_SZ);
 	update_vpd_b0(lu, &worm);
 }
 

--- a/usr/pm/ult3580_pm.c
+++ b/usr/pm/ult3580_pm.c
@@ -323,7 +323,6 @@ static void update_vpd_lbp(struct lu_phy_attr *lu) {
 }
 
 static void init_ult_inquiry(struct lu_phy_attr *lu) {
-	int		pg;
 	uint8_t worm;
 	uint8_t local_TapeAlert[8] =
 		{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
@@ -336,39 +335,19 @@ static void init_ult_inquiry(struct lu_phy_attr *lu) {
 	lu->inquiry[5] |= (((struct priv_lu_ssc *)lu->lu_private)->pm->drive_supports_LBP) ? 1 : 0;
 
 	/* Extended INQUIRY Data VPD page */
-	pg			   = PCODE_OFFSET(0x86);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_86_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0x86, VPD_86_SZ);
 	update_vpd_86(lu, ((struct priv_lu_ssc *)lu->lu_private)->pm);
 
 	/* Sequential Access device capabilities - Ref: 8.4.2 */
-	pg			   = PCODE_OFFSET(0xb0);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B0_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb0, VPD_B0_SZ);
 	update_vpd_b0(lu, &worm);
 
 	/* Manufacture-assigned serial number - Ref: 8.4.3 */
-	pg			   = PCODE_OFFSET(0xb1);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B1_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb1, VPD_B1_SZ);
 	update_vpd_b1(lu, lu->lu_serial_no);
 
 	/* TapeAlert supported flags - Ref: 8.4.4 */
-	pg			   = PCODE_OFFSET(0xb2);
-	lu->lu_vpd[pg] = alloc_vpd(VPD_B2_SZ);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xb2, VPD_B2_SZ);
 	update_vpd_b2(lu, &local_TapeAlert);
 
 	/* Logical Block Protection - Ref: 6.3.13.13 (LTO-9 reference guide) */
@@ -376,31 +355,19 @@ static void init_ult_inquiry(struct lu_phy_attr *lu) {
 		/* two pages ? - one for CRC32C and one for RS-CRC */
 		int pg_size = (((struct priv_lu_ssc *)lu->lu_private)->pm->drive_supports_LBP == LBP_RSCRC) ? VPD_B5_SZ : VPD_B5_SZ + VPD_B5_SZ;
 
-		pg			   = PCODE_OFFSET(0xb5);
-		lu->lu_vpd[pg] = alloc_vpd(pg_size + 12); /* header page, one page for 'disabled' LBP + one or two for RS-CRC / CRC32C */
-		if (!lu->lu_vpd[pg]) {
-			MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-			exit(-ENOMEM);
-		}
+		/* header page, one page for 'disabled' LBP + one or two for
+		 * RS-CRC / CRC32C
+		 */
+		add_vpd_page(lu, 0xb5, pg_size + 12);
 		update_vpd_lbp(lu);
 	}
 
 	/* VPD page 0xC0 */
-	pg			   = PCODE_OFFSET(0xc0);
-	lu->lu_vpd[pg] = alloc_vpd(43);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xc0, 43);
 	update_vpd_ult_c0(lu);
 
 	/* VPD page 0xC1 */
-	pg			   = PCODE_OFFSET(0xc1);
-	lu->lu_vpd[pg] = alloc_vpd(28);
-	if (!lu->lu_vpd[pg]) {
-		MHVTL_ERR("Failed to malloc(): Line %d", __LINE__);
-		exit(-ENOMEM);
-	}
+	add_vpd_page(lu, 0xc1, 28);
 	update_vpd_ult_c1(lu, lu->lu_serial_no);
 }
 

--- a/usr/spc.c
+++ b/usr/spc.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <inttypes.h>
 #include <assert.h>
+#include <errno.h>
 #include "be_byteshift.h"
 #include "mhvtl_scsi.h"
 #include "vtl_common.h"
@@ -62,6 +63,23 @@ struct vpd *alloc_vpd(uint16_t sz) {
 void dealloc_vpd(struct vpd *pg) {
 	free(pg->data);
 	free(pg);
+}
+
+/* Allocate a VPD page and install it in the logical unit. Personality
+ * modules build their pages during start up, where there is nothing
+ * sensible to do about an allocation failure, so this keeps the
+ * abort-on-failure behaviour every call site had written out by hand.
+ */
+struct vpd *add_vpd_page(struct lu_phy_attr *lu, uint8_t pcode, uint16_t sz) {
+	int pg = PCODE_OFFSET(pcode);
+
+	lu->lu_vpd[pg] = alloc_vpd(sz);
+	if (!lu->lu_vpd[pg]) {
+		MHVTL_ERR("Failed to allocate %d bytes for VPD page 0x%02x",
+				  sz, pcode);
+		exit(-ENOMEM);
+	}
+	return lu->lu_vpd[pg];
 }
 
 uint8_t spc_inquiry(struct scsi_cmd *cmd) {
@@ -268,7 +286,7 @@ uint8_t resp_spc_pro(uint8_t *cdb, struct mhvtl_ds *dbuf_p) {
 		*sam_stat = SAM_STAT_RESERVATION_CONFLICT;
 		break;
 	case 3: /* CLEAR */
-		if (!SPR_Reservation_Key && !SPR_Reservation_Key) {
+		if (!SPR_Reservation_Key) {
 			*sam_stat = SAM_STAT_RESERVATION_CONFLICT;
 		} else {
 			if (RK == SPR_Reservation_Key) {

--- a/usr/vtllib.c
+++ b/usr/vtllib.c
@@ -2244,24 +2244,11 @@ void init_smc_mode_pages(struct lu_phy_attr *lu) {
 	add_mode_device_capabilities(lu);
 }
 
-void bubbleSort(int *array, int size) {
-	int swapped;
-	int i;
-	int j;
+static int cmp_int(const void *a, const void *b) {
+	int x = *(const int *)a;
+	int y = *(const int *)b;
 
-	for (i = 1; i < size; i++) {
-		swapped = 0;
-		for (j = 0; j < size - i; j++) {
-			if (array[j] > array[j + 1]) {
-				int temp	 = array[j];
-				array[j]	 = array[j + 1];
-				array[j + 1] = temp;
-				swapped		 = 1;
-			}
-		}
-		if (!swapped)
-			break; /* if it is sorted then stop */
-	}
+	return (x > y) - (x < y);
 }
 
 void sort_library_slot_type(struct lu_phy_attr *lu, struct smc_type_slot *type) {
@@ -2274,7 +2261,7 @@ void sort_library_slot_type(struct lu_phy_attr *lu, struct smc_type_slot *type) 
 	arr[2] = smc_p->pm->start_map;
 	arr[3] = smc_p->pm->start_storage;
 
-	bubbleSort(arr, 4);
+	qsort(arr, 4, sizeof(arr[0]), cmp_int);
 
 	for (i = 0; i < 4; i++) {
 		if (smc_p->pm->start_drive == arr[i]) {


### PR DESCRIPTION
No functional change.

- `add_vpd_page()` replaces the allocate, check for NULL and exit sequence that was written out 41 times across the personality modules.
- `qsort()` replaces a hand-rolled bubble sort.
- Remove `CreateNewQueue()`, which nothing calls.
- PERSISTENT RESERVE OUT CLEAR tested the same operand twice.

## Testing

Ubuntu 26.04, kernel 7.0.0-30. One drive was configured for every personality module this branch touches, and the complete SCSI surface of each was captured on master and on this branch and compared byte for byte:

- Devices: STK L700 changer, ULT3580-TD9, ULT3580-TDA, HP Ultrium 6-SCSI, IBM 03592E07, STK T10000C, STK T9840D, QUANTUM SDLT600, SONY SDX-700C, and a generic product identification that falls back to the default SSC personality.
- Captured per device: standard INQUIRY, VPD pages 00h, 80h, 83h, B0h, B1h, B2h, C0h and C1h, all mode pages, the full REPORT SUPPORTED OPERATION CODES list, and REPORT DENSITY SUPPORT.

41 files per side. The only difference is three lines carrying the compile time stamp that mhvtl embeds from `__TIME__`, because the two builds ran a minute apart:

```
< 10  00 00 00 00 31 36 31 32  33 34 ...     "161234"
> 10  00 00 00 00 31 36 31 33  30 32 ...     "161302"
```

Everything else, including every VPD page the refactored allocation produces, is identical.
