### PR TITLE
fix(etc): generate firmware levels that LTFS accepts

### DIFF
--- a/etc/generate_device_conf.in
+++ b/etc/generate_device_conf.in
@@ -235,7 +235,8 @@ add_ibm_ultrium_5_drive()
 	SLOT=$7
 	VENDORID="IBM"
 	PRODUCTID="ULT3580-TD5"
-	PRODUCTREV="550V"
+	# LTFS refuses to open an LTO-5 drive reporting less than B170.
+	PRODUCTREV="B170"
 	DENSITY="50"
 
 	add_drive $ID $CH $TARGET $LUN $VENDORID $PRODUCTID $PRODUCTREV $UNITSERNO $LIB $SLOT $DENSITY
@@ -314,12 +315,13 @@ add_ibm_ultrium_8_drive()
 	VENDORID="IBM"
 	PRODUCTID="ULT3580-TD8"
 	#### According to IBM LTO SCSI reference: REV is built of
-	 # "ABCD" - so 2160 decodes as Year 2022 (2), Jan (1), Day (6th), Version '0'
+	 # "ABCD" - so HB81 decodes as Year 2017 (H), Nov (B), Day (8th), Version '1'
 	 # A = last digit char of year
 	 # B = Month, 1 - 9, A, B, C
 	 # C = Day, 1-9, A-V
 	 # D = Version
-	PRODUCTREV="2160"
+	 # LTFS refuses to open an LTO-8 drive reporting less than HB81.
+	PRODUCTREV="HB81"
 	DENSITY="50"
 
 	add_drive $ID $CH $TARGET $LUN $VENDORID $PRODUCTID $PRODUCTREV $UNITSERNO $LIB $SLOT $DENSITY


### PR DESCRIPTION
The generator emits firmware revisions that LTFS rejects, so a generated LTO-5 or LTO-8 drive cannot be opened by it.

- LTO-5: `550V` -> `B170`
- LTO-8: `2160` -> `HB81`

LTFS compares the reported revision against a per-generation minimum and refuses the drive below it. Both new values are the minimums LTFS accepts.

Both are also well-formed per the IBM LTO SCSI Reference (GA32-0928-06), which defines the field as `YMDV` - year, month, day, version: `B170` is 2011-01-07 v0 and `HB81` is 2017-11-08 v1. The previous LTO-5 value `550V` was not well-formed: `0` is not in the documented day set (`1`-`9`, `A`-`V`).

Tested on a Linux host with both generations: at the old values LTFS refused to open the drive; at the new values `mkltfs` reported `Medium formatted successfully`.